### PR TITLE
DOC: Add explicit listing of dependencies in separate file.

### DIFF
--- a/DEPENDS.txt
+++ b/DEPENDS.txt
@@ -1,3 +1,7 @@
-skfuzzy
-NumPy>=1.6.0
-SciPy>=0.9.0
+#################################
+# Requirements for scikit-fuzzy #
+#################################
+# The current requirements to install and run the package are stored in
+# ./setup.py and are grabbed from there at install time via Pip.
+
+-e .


### PR DESCRIPTION
The README directs users to a `DEPENDS.txt` file which now exists.

The package dependencies at this time are minimal: 
- NumPy >= 1.6
- SciPy >= 0.9
