### PR TITLE
ENH/FIX: Overhaul Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,54 +1,83 @@
 # vim ft=yaml
-# travis-ci.org definition for skfuzzy build
-#
-# Check changes to this file on http://lint.travis-ci.org/
+# travis-ci.org definition for skfuzzy build, modified from scikit-image
+
+# After changing this file, check it on:
+#   http://lint.travis-ci.org/
 
 language: python
 
-python:
-    - 2.6
 
-matrix:
-    include:
-        - python: 2.7
-          env:
-            - PYTHON=python
-            - PYVER=2.x
-        - python: 3.2
-          env:
-            - PYTHON=python3
-            - PYVER=3.x
-    exclude:
-        - python: 2.6
+#  The Travis python is set to 3.2 for all builds, since we use the default python for the 3.2 build and the anaconda python otherwise
+python:
+    - 3.2
+
+env:
+    - ENV="python=2.6 numpy=1.6"
+    - ENV="python=2.7 numpy"
+    - ENV="python=3.2"
+    - ENV="python=3.3 numpy"
+    - ENV="python=3.4 numpy"
 
 virtualenv:
     system_site_packages: true
 
 before_install:
+    - export DISPLAY=:99.0
+    - sh -e /etc/init.d/xvfb start
     - sudo apt-get update
-    - sudo apt-get install $PYTHON-numpy
-    - wget https://raw.githubusercontent.com/numpy/numpy/master/numpy/_import_tools.py -O /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/_import_tools.py
-    - sudo apt-get install $PYTHON-scipy
-    - if [[ $PYVER == '2.x' ]]; then
-    -   sudo apt-get install $PYTHON-matplotlib
-    - fi
-    - if [[ $PYVER == '3.x' ]]; then
-    -   sudo apt-get install $PYTHON-setuptools
-    -   pip install --use-mirrors matplotlib
-    - fi
-    # - pip install --use-mirrors cython  # If skfuzzy ever uses Cython
-    - pip install --use-mirrors flake8
-    - pip install --use-mirrors nose-cov
-    - pip install --use-mirrors coveralls
+
+    # Python 3.2 is not supported by Miniconda, so we use the package manager for that run.
+    # NumPy has a bug in python 3 that is only fixed in the latest version,
+    #  hence the below wget of numpy/_import_tools.py from github.
+    - if [[ $ENV == python=3.2 ]]; then
+        sudo apt-get install python3-numpy;
+        wget https://raw.githubusercontent.com/numpy/numpy/master/numpy/_import_tools.py -O /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/_import_tools.py;
+        sudo apt-get install python3-scipy;
+        travis_retry pip install cython flake8 six;
+      else
+        wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+        bash miniconda.sh -b -p $HOME/miniconda;
+        export PATH="$HOME/miniconda/bin:$PATH";
+        hash -r;
+        conda config --set always_yes yes;
+        conda update conda;
+        conda info -a;
+        travis_retry conda create -n test $ENV six scipy pip flake8 nose;
+        source activate test;
+      fi
+    - travis_retry pip install coveralls pillow
 
 install:
-    - sudo $PYTHON setup.py install
+    - tools/header.py "Dependency versions"
+    - tools/build_versions.py
+    - export PYTHONWARNINGS=all
+    - python setup.py build_ext --inplace
 
 script:
-    # Run tests
-    - nosetests --exe -v --with-cov --cov skfuzzy --cov-config .coveragerc skfuzzy
+    # Run all tests with minimum dependencies
+    - nosetests --exe -v skfuzzy
+
+    # Run pep8 and flake tests
+    - flake8 --exit-zero --exclude=test_*,six.py skfuzzy doc/examples
+
+    # Install optional dependencies to get full test coverage
+    # Notes:
+    # - pyfits and imread do NOT support py3.2
+    # - Use the png headers included in anaconda (from matplotlib install)
+    # TODO: Remove the libm removal when anaconda fixes their libraries
+    #   The solution was suggested here
+    #   https://groups.google.com/a/continuum.io/forum/#!topic/anaconda/-DLG2ZdTkw0
+    - if [[ $ENV == python=3.2 ]]; then
+        travis_retry pip install -q matplotlib;
+      else
+        sudo cp ~/miniconda/envs/test/include/png* /usr/include;
+        rm ~/miniconda/envs/test/lib/libm-2.5.so;
+        rm ~/miniconda/envs/test/lib/libm.*;
+        sudo apt-get install -qq libtiff4-dev libwebp-dev xcftools;
+        travis_retry pip install -q imread;
+      fi
 
 after_success:
-    - if [[ $PYVER == '3.x' ]]; then
-    -   coveralls
-    - fi
+    - if [[ $ENV == python=3.3* ]]; then
+          coveralls;
+      fi

--- a/tools/build_versions.py
+++ b/tools/build_versions.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import numpy as np
+import scipy as sp
+from PIL import Image
+import six
+
+for m in (np, sp, Image, six):
+    if not m is None:
+        if m is Image:
+            print('PIL'.rjust(10), ' ', Image.VERSION)
+        else:
+            print(m.__name__.rjust(10), ' ', m.__version__)

--- a/tools/header.py
+++ b/tools/header.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import sys
+
+screen_width = 50
+
+print('*' * screen_width)
+
+if len(sys.argv) > 1:
+    header = ' '.join(sys.argv[1:])
+    print('*', header.center(screen_width - 4), '*')
+    print('*' * screen_width)


### PR DESCRIPTION
Overhaul of our Travis build, now compliant with the new Travis syntax/requirements and uses Anaconda under the hood.

Also, tests are now executed against Python 2.6, 2.7, 3.2, 3.3, and 3.4!

Approach modified from `scikit-image`.
