### PR TITLE
FIX: Use explicit truncating division to solve DeprecationWarning

### DIFF
--- a/skfuzzy/image/shape.py
+++ b/skfuzzy/image/shape.py
@@ -97,7 +97,7 @@ def view_as_blocks(arr_in, block_shape):
     # -- restride the array to build the block view
     arr_in = np.ascontiguousarray(arr_in)
 
-    new_shape = tuple(arr_shape / block_shape) + tuple(block_shape)
+    new_shape = tuple(arr_shape // block_shape) + tuple(block_shape)
     new_strides = tuple(arr_in.strides * block_shape) + arr_in.strides
 
     arr_out = as_strided(arr_in, shape=new_shape, strides=new_strides)


### PR DESCRIPTION
Simple fix for Python 3.x forcing truncating division, thus avoiding a NumPy DeprecationWarning regarding use of float instead of int.
