### PR TITLE
TST/ENH: FIRE tests and `fuzzyresolution` fully functional in fire2d

### DIFF
--- a/skfuzzy/filters/fire.py
+++ b/skfuzzy/filters/fire.py
@@ -106,6 +106,8 @@ def fire2d(im, l1=0, l2=255, fuzzyresolution=1):
         Upper limit of filtering range.
     fuzzyresolution : float, default = 1
         Resolution of fuzzy input sequence, or spacing between [-l2+1, l2-1].
+        The default assumes an integer input; for floating point images a
+        decimal value should be used approximately equal to the bit depth.
 
     Returns
     -------
@@ -129,11 +131,16 @@ def fire2d(im, l1=0, l2=255, fuzzyresolution=1):
     im = padimg(im.astype(float), 1, mode='reflect')
 
     # Fuzzy input sequence
-    dx = np.arange(- l2 + 1, l2 - 1, fuzzyresolution)
+    dx = np.arange(- l2 + fuzzyresolution,
+                     l2 - fuzzyresolution, fuzzyresolution)
 
     # Fuzzy membership functions
-    po = np.atleast_2d(trimf(dx, [l1,      l2 - 1,  l2 - 1]))
-    ne = np.atleast_2d(trimf(dx, [1 - l2,  1 - l2,    - l1]))
+    po = np.atleast_2d(trimf(dx, [l1,
+                                  l2 - fuzzyresolution,
+                                  l2 - fuzzyresolution]))
+    ne = np.atleast_2d(trimf(dx, [fuzzyresolution - l2,
+                                  fuzzyresolution - l2,
+                                  - l1]))
 
     # Combine into matrix
     multi_stack_rules = np.hstack([po.T, ne.T])

--- a/skfuzzy/filters/tests/test_fire.py
+++ b/skfuzzy/filters/tests/test_fire.py
@@ -1,0 +1,57 @@
+"""Tests for the array pading functions.
+
+"""
+from __future__ import division, absolute_import, print_function
+
+import os
+import numpy as np
+from numpy.random import randint
+import skfuzzy.image
+from skfuzzy.filters import fire1d, fire2d
+
+
+def _generatedata_1d(length=128, seed=42):
+    # Make a pure sine tone
+    x = np.arange(length) * 2 * np.pi / length
+    y = np.sin(x)
+
+    # Add some deterministic salt and pepper
+    np.random.seed(seed)
+    y[randint(0, 127, 20)] = 1   # Salt
+    y[randint(0, 127, 20)] = -1  # Pepper
+
+    return y
+
+
+class TestFire1D():
+    def __init__(self):
+        self.data = _generatedata_1d()
+
+    def test_fire1d(self):
+        fired = fire1d(self.data)
+        assert fired.std() < 0.65        # Lower variation
+        assert fired[:64].min() >= -0.1  # Correction terminates at zero
+        assert fired[64:].max() <= 0.1
+
+
+class TestFire2D():
+    def __init__(self):
+        # Normalized astronaut image
+        self.im = np.load(
+            os.path.join(skfuzzy.image.__path__[0],
+                         'astronaut_gray.npy')).astype(np.float64)
+
+        # Add some deterministic salt and pepper
+        np.random.seed(42)
+        x, y = self.im.shape
+        num = 13000
+        self.im[randint(0, x, num), randint(0, y, num)] = 0  # Salt
+        self.im[randint(0, x, num), randint(0, y, num)] = 1  # Pepper
+
+    def test_fire2d(self):
+        fired = fire2d(self.im, fuzzyresolution=0.1)
+
+        assert fired.std() < self.im.std()
+
+if __name__ == '__main__':
+    np.testing.run_module_suite()


### PR DESCRIPTION
Full test coverage in `skfuzzy.filters` and enhancement to make the `fuzzyresolution` kwarg usable in `fire2d`.