### PR TITLE
FIX: Fix the doc build to actually include the API docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,7 +12,7 @@ PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
 ALLSPHINXOPTS   = -d build/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 DEST = build
-.PHONY: all help clean html dirhtml pickle json htmlhelp qthelp latex changes linkcheck doctest gitwash gh-pages random_gallery
+.PHONY: all api help clean html dirhtml pickle json htmlhelp qthelp latex changes linkcheck doctest gitwash gh-pages random_gallery
 
 all: html
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,10 +19,10 @@ import os
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, os.path.abspath('.'))
-curpath = os.path.dirname(__file__)
-sys.path.append(os.path.join(curpath, '..', 'ext'))
+curpath = os.path.abspath('.')
+sys.path.append(os.path.abspath(os.path.join(curpath, '..', 'ext')))
 
-src_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), '..')
+src_dir = os.path.abspath(os.path.join(curpath, '..', '..'))
 sys.path.insert(0, src_dir)
 
 module = 'skfuzzy'
@@ -68,7 +68,7 @@ else:
 
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates', '~/src/scikit-fuzzy/docs/source/_templates/']
+templates_path = ['./_templates/']
 
 # The suffix of source filenames.
 source_suffix = '.txt'

--- a/docs/source/index.txt
+++ b/docs/source/index.txt
@@ -15,7 +15,7 @@ Sections
    :hidden:
 
     overview
-    api/api
+    api
     install
     user_guide
     contribute

--- a/docs/source/overview.txt
+++ b/docs/source/overview.txt
@@ -1,26 +1,26 @@
-SciKit Fuzzy
+SciKit-Fuzzy
 ============
 
-The `scikit-fuzzy ...
-
-It is written in the `Python <http://www.python.org>`_ language.
+Scikit-Fuzzy is a collection of fuzzy logic algorithms for
+`SciPy <http://scipy.org>`_ written in the
+`Python <http://www.python.org>`_ language.
 
 This `SciKit <http://scikits.appspot.com>`_ is developed by the SciPy
-community.  All contributions are most welcome!  Please join us on the
-mailing list (address provided below).
+community.  Contributions are welcome!  Please join us on the mailing list
+or our persistent chatroom on Gitter.IM
 
 Homepage
 --------
-
+Coming soon :superscript:`TM`
 
 Source, bugs and patches
 ------------------------
 http://github.com/scikit-fuzzy/scikit-fuzzy
 
+Gitter.IM
+---------
+https://gitter.im/scikit-fuzzy/scikit-fuzzy
+
 Mailing List
 ------------
 http://groups.google.com/group/scikit-fuzzy
-
-Contact
--------
-


### PR DESCRIPTION
The doc build changes in #43 made Sphinx lose track of the API documentation. That's a problem, since right now the majority of the documentation *is* the API documentation. On my system this wasn't apparent because the old cache was being used in subsequent builds, but after a `make clean` suddenly no API docs could be found.

These changes fix that. Along for the ride: adding the `api` target to the Makefile .PHONY and improving the Overview page.