### PR TITLE
Fix lambda_cut with lcut=1 and add lambda_cut_boundaries function.

### DIFF
--- a/skfuzzy/defuzzify/__init__.py
+++ b/skfuzzy/defuzzify/__init__.py
@@ -9,7 +9,8 @@ __all__ = ['arglcut',
            'defuzz',
            'lambda_cut_series',
            'lambda_cut',
+           'lambda_cut_boundaries',
            ]
 
 from .defuzz import (arglcut, centroid, dcentroid, defuzz, lambda_cut_series,
-                     lambda_cut)
+                     lambda_cut, lambda_cut_boundaries)

--- a/skfuzzy/defuzzify/defuzz.py
+++ b/skfuzzy/defuzzify/defuzz.py
@@ -4,6 +4,7 @@ defuzz.py : Various methods for defuzzification and lambda-cuts, to convert
 
 """
 import numpy as np
+from ..image.arraypad import pad
 
 
 def arglcut(ms, lambdacut):
@@ -289,9 +290,13 @@ def lambda_cut_boundaries(x, mfx, lambdacut):
         Floating point values of `x` where `mfx` crosses `lambdacut`.
         Calculated using linear interpolation.
 
+    Note
+    ----
+    This function will only calculate
+
     """
     # Pad binary set two values by extension
-    mfxx = np.pad(mfx, [2, 2], 'edge')
+    mfxx = pad(mfx, [2, 2], 'edge')
 
     # Find binary lambda cut set
     lcutset = lambda_cut(mfxx, lambdacut)

--- a/skfuzzy/defuzzify/defuzz.py
+++ b/skfuzzy/defuzzify/defuzz.py
@@ -292,7 +292,12 @@ def lambda_cut_boundaries(x, mfx, lambdacut):
 
     Note
     ----
-    This function will only calculate
+    The values returned by this function can be thought of as intersections
+    between a hypothetical horizontal line at ``lambdacut`` and the membership
+    function ``mfx``. This function assumes the end values of ``mfx`` continue
+    on forever in positive and negative directions. This means there will NOT
+    be crossings found exactly at the bounds of ``x`` unless the value of
+    ``mfx`` at the boundary is exactly ``lambdacut``.
 
     """
     # Pad binary set two values by extension
@@ -305,14 +310,15 @@ def lambda_cut_boundaries(x, mfx, lambdacut):
     crossings = np.convolve(lcutset, [1, -1])[1:-1]
     argcrossings = np.where(np.abs(crossings) > 0)[0] - 1
 
-    # Calculate exact crossing points
+    # Calculate exact crossing points, removing the last padded value
     boundaries = []
     for cross in argcrossings:
         idx = slice(cross - 1, cross + 1)
         boundaries.append(
             x[cross - 1] + _interp_universe(x[idx], mfx[idx], lambdacut))
 
-    return np.r_[boundaries]
+    # Eliminate degenerate points at peaks with np.unique
+    return np.unique(np.r_[boundaries])
 
 
 def _support(x, mfx):

--- a/skfuzzy/defuzzify/tests/test_defuzz.py
+++ b/skfuzzy/defuzzify/tests/test_defuzz.py
@@ -89,5 +89,11 @@ def test_lambda_cut_boundaries():
     assert_allclose(fuzz.lambda_cut_boundaries(x, mfx, 0.2), np.r_[1.2, 9.4])
 
 
+def test_lambda_cut_boundaries_degenerate():
+    x = np.arange(11)
+    mfx = fuzz.trimf(x, [0, 7, 10])
+    assert_allclose(fuzz.lambda_cut_boundaries(x, mfx, 1), np.r_[7])
+
+
 if __name__ == '__main__':
     np.testing.run_module_suite()

--- a/skfuzzy/defuzzify/tests/test_defuzz.py
+++ b/skfuzzy/defuzzify/tests/test_defuzz.py
@@ -69,13 +69,24 @@ def test_lambda_cut_series():
     x = np.arange(21) - 10
     mfx = fuzz.trimf(x, [-2, 3, 5])
 
-    expected = np.array([[ 0.  , -2.,  5.],
-                         [ 0.25,  0.,  4.],
-                         [ 0.5 ,  1.,  4.],
-                         [ 0.75,  2.,  3.],
-                         [ 1.  ,  3.,  3.]])
+    expected = np.array([[0.  , -2.,  5.],
+                         [0.25,  0.,  4.],
+                         [0.5 ,  1.,  4.],
+                         [0.75,  2.,  3.],
+                         [1.  ,  3.,  3.]])
 
     assert_allclose(expected, fuzz.lambda_cut_series(x, mfx, 5))
+
+
+def test_lambda_cut_boundaries():
+    x = np.arange(10)
+    mfx = fuzz.trapmf(x, [0, 6, 7, 10])
+
+    assert_allclose(fuzz.lambda_cut_boundaries(x, mfx, 0.2), np.r_[1.2])
+
+    x = np.arange(11)
+    mfx = fuzz.trapmf(x, [0, 6, 7, 10])
+    assert_allclose(fuzz.lambda_cut_boundaries(x, mfx, 0.2), np.r_[1.2, 9.4])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Satisfies #48 - take a look @pbreach!

A fast and efficient method to detect an arbitrary number of cuts was simple to implement with convolution, then slightly tricky to make robust at edges. Symmetric padding by two elements should not materially affect the runtime of this routine.

This implementation **only** reports boundaries *that actually cross the lambda cut value within the provided membership function*. If one edge of a membership function was 0.3, a lambda cut value of 0.2 would not report the final value as a boundary. Put differently, it makes absolutely no assumptions about the membership function outside the provided discrete range.