### PR TITLE
DOCFIX: Resolve errors in Sphinx build and improve docstrings.

### DIFF
--- a/skfuzzy/cluster/_cmeans.py
+++ b/skfuzzy/cluster/_cmeans.py
@@ -56,7 +56,7 @@ def _distance(data, centers):
 
     See Also
     --------
-    ``scipy.spatial.distance.cdist``
+    scipy.spatial.distance.cdist
 
     """
     return cdist(data, centers).T
@@ -86,7 +86,7 @@ def _fp_coeff(u):
 
 def cmeans(data, c, m, error, maxiter, init=None, seed=None):
     """
-    Fuzzy c-means clustering algorithm for training.
+    Fuzzy c-means clustering algorithm [1]_.
 
     Parameters
     ----------
@@ -131,7 +131,7 @@ def cmeans(data, c, m, error, maxiter, init=None, seed=None):
 
     Notes
     -----
-    The algorithm implemented is from `Ross et al.`_
+    The algorithm implemented is from Ross et al. [1]_.
 
     References
     ----------
@@ -176,14 +176,14 @@ def cmeans(data, c, m, error, maxiter, init=None, seed=None):
 def cmeans_predict(test_data, cntr_trained, m, error, maxiter, init=None,
                    seed=None):
     """
-    Fuzzy c-means clustering algorithm for training.
+    Prediction of new data in given a trained fuzzy c-means framework [1]_.
 
     Parameters
     ----------
     test_data : 2d array, size (S, N)
-        New, independent data set to be predicted based on trained c-means.
-        N is the number of data sets; S is the number of features within each
-        sample vector.
+        New, independent data set to be predicted based on trained c-means
+        from ``cmeans``. N is the number of data sets; S is the number of
+        features within each sample vector.
     cntr_trained : 2d array, size (S, c)
         Location of trained centers from prior training c-means.
     m : float
@@ -218,9 +218,9 @@ def cmeans_predict(test_data, cntr_trained, m, error, maxiter, init=None,
 
     Notes
     -----
-    `Ross et al.`_ did not include a prediction algorithm to go along with
+    Ross et al. [1]_ did not include a prediction algorithm to go along with
     fuzzy c-means. This prediction algorithm works by repeating the clustering
-    with fixed centers; this efficiently finds the fuzzy membership at all
+    with fixed centers, then efficiently finds the fuzzy membership at all
     points.
 
     References

--- a/skfuzzy/defuzzify/defuzz.py
+++ b/skfuzzy/defuzzify/defuzz.py
@@ -28,8 +28,10 @@ def arglcut(ms, lambdacut):
     Notes
     -----
     This is a convenience function for `np.nonzero(lambdacut <= ms)` and only
-    half of the indexing operation that can be more concisely accomplished via
-        ms[lambdacut <= ms]
+    half of the indexing operation that can be more concisely accomplished
+    via::
+
+      ms[lambdacut <= ms]
 
     """
     return np.nonzero(lambdacut <= ms)
@@ -53,7 +55,7 @@ def centroid(x, mfx):
 
     See also
     --------
-    DCENTROID, DEFUZZ
+    skfuzzy.defuzzify.defuzz, skfuzzy.defuzzify.dcentroid
 
     """
     return (x * mfx).sum() / np.fmax(mfx.sum(),
@@ -80,7 +82,7 @@ def dcentroid(x, mfx, x0):
 
     See also
     --------
-    CENTROID, DEFUZZ
+    skfuzzy.defuzzify.defuzz, skfuzzy.defuzzify.centroid
 
     """
     x = x - x0
@@ -104,18 +106,18 @@ def defuzz(x, mfx, mode):
         Controls which defuzzification method will be used.
         * 'centroid': Centroid of area
         * 'bisector': bisector of area
-        * 'mom'        : mean of maximum
-        * 'som'        : min of maximum
-        * 'lom'        : max of maximum
+        * 'mom'     : mean of maximum
+        * 'som'     : min of maximum
+        * 'lom'     : max of maximum
 
     Returns
     -------
     u : float or int
         Defuzzified result.
 
-    See also
+    See Also
     --------
-    CENTROID, DCENTROID
+    skfuzzy.defuzzify.centroid, skfuzzy.defuzzify.dcentroid
 
     """
     mode = mode.lower()

--- a/skfuzzy/filters/fire.py
+++ b/skfuzzy/filters/fire.py
@@ -10,7 +10,7 @@ from ..membership import trimf
 
 def fire1d(x, l1=0, l2=1):
     """
-    1-D fuzzy filtering using Fuzzy Inference Ruled by Else-action (FIRE)
+    1-D filtering using Fuzzy Inference Ruled by Else-action (FIRE) [1]_
 
     FIRE filtering is nonlinear, and is specifically designed to remove
     impulse (salt and pepper) noise.
@@ -18,11 +18,11 @@ def fire1d(x, l1=0, l2=1):
     Parameters
     ----------
     x : 1d array or iterable
-        Input sequence, filtered range limited by `l1` and `l2`.
+        Input sequence, filtered range limited by ``l1`` and ``l2``.
     l1 : float
-        Lower input range limit for `x`.
+        Lower input range limit for ``x``.
     l2 : float
-        Upper input range limit for `x`.
+        Upper input range limit for ``x``.
 
     Returns
     -------
@@ -31,7 +31,7 @@ def fire1d(x, l1=0, l2=1):
 
     Notes
     -----
-    Filtering occurs for `l1` < |`x`| < `l2`; for |`x`| < `l1` there is no
+    Filtering occurs for ``l1 < |x| < l2``; for ``|x| < l1`` there is no
     effect.
 
     References
@@ -91,7 +91,7 @@ def fire1d(x, l1=0, l2=1):
 
 def fire2d(im, l1=0, l2=255, fuzzyresolution=1):
     """
-    2-D fuzzy filtering using Fuzzy Inference Ruled by Else-action (FIRE)
+    2-D filtering using Fuzzy Inference Ruled by Else-action (FIRE) [1]_
 
     FIRE filtering is nonlinear, and is specifically designed to remove
     impulse (salt and pepper) noise.
@@ -116,7 +116,7 @@ def fire2d(im, l1=0, l2=255, fuzzyresolution=1):
 
     Notes
     -----
-    Filtering occurs for `l1` < |`x`| < `l2`; outside this range the data is
+    Filtering occurs for ``l1 < |x| < l2``; outside this range the data is
     unaffected.
 
     References

--- a/skfuzzy/fuzzymath/fuzzy_ops.py
+++ b/skfuzzy/fuzzymath/fuzzy_ops.py
@@ -195,6 +195,10 @@ def fuzzy_add(x, a, y, b):
     Uses Zadeh's Extension Principle as described in Ross, Fuzzy Logic with
     Engineering Applications (2010), pp. 414, Eq. 12.17.
 
+    If these results are unexpected and your membership functions are convex,
+    consider trying the ``skfuzzy.dsw_*`` functions for fuzzy mathematics
+    using interval arithmetic via the restricted Dong, Shah, and Wong method.
+
     """
     # a and x, and b and y, are formed into (MxN) matrices.  The former has
     # identical rows; the latter identical identical columns.
@@ -275,6 +279,10 @@ def fuzzy_div(x, a, y, b):
     Uses Zadeh's Extension Principle from Ross, Fuzzy Logic w/Engineering
     Applications, (2010), pp.414, Eq. 12.17.
 
+    If these results are unexpected and your membership functions are convex,
+    consider trying the ``skfuzzy.dsw_*`` functions for fuzzy mathematics
+    using interval arithmetic via the restricted Dong, Shah, and Wong method.
+
     """
     # a and x, and b and y, are formed into (MxN) matrices.  The former has
     # identical rows; the latter identical identical columns.
@@ -335,6 +343,10 @@ def fuzzy_min(x, a, y, b):
     -----
     Uses Zadeh's Extension Principle from Ross, Fuzzy Logic w/Engineering
     Applications, (2010), pp.414, Eq. 12.17.
+
+    If these results are unexpected and your membership functions are convex,
+    consider trying the ``skfuzzy.dsw_*`` functions for fuzzy mathematics
+    using interval arithmetic via the restricted Dong, Shah, and Wong method.
 
     """
     # a and x, and b and y, are formed into (MxN) matrices.  The former has
@@ -397,6 +409,10 @@ def fuzzy_mult(x, a, y, b):
     Uses Zadeh's Extension Principle from Ross, Fuzzy Logic w/Engineering
     Applications, (2010), pp.414, Eq. 12.17.
 
+    If these results are unexpected and your membership functions are convex,
+    consider trying the ``skfuzzy.dsw_*`` functions for fuzzy mathematics
+    using interval arithmetic via the restricted Dong, Shah, and Wong method.
+
     """
     # a and x, and b and y, are formed into (MxN) matrices.  The former has
     # identical rows; the latter identical identical columns.
@@ -457,6 +473,10 @@ def fuzzy_sub(x, a, y, b):
     -----
     Uses Zadeh's Extension Principle from Ross, Fuzzy Logic w/Engineering
     Applications, (2010), pp.414, Eq. 12.17.
+
+    If these results are unexpected and your membership functions are convex,
+    consider trying the ``skfuzzy.dsw_*`` functions for fuzzy mathematics
+    using interval arithmetic via the restricted Dong, Shah, and Wong method.
 
     """
     # a and x, and b and y, are formed into (MxN) matrices.  The former has
@@ -881,6 +901,10 @@ def sigmoid(x, power, split=0.5):
     The sigmoid used herein is defined as::
 
       y = 1 / (1 + exp(- exp(- power * (x-split))))
+
+    See Also
+    --------
+    skfuzzy.fuzzymath.contrast
 
     """
     return 1. / (1. + np.exp(- power * (x - split)))

--- a/skfuzzy/intervals/intervalops.py
+++ b/skfuzzy/intervals/intervalops.py
@@ -52,6 +52,7 @@ def divval(interval1, interval2):
     Returns
     -------
     z : 2-element array
+        Interval result of interval1 / interval2.
 
     """
     # Handle arrays
@@ -67,29 +68,39 @@ def divval(interval1, interval2):
 
 def dsw_add(x, mfx, y, mfy, n):
     """
-    Uses the restricted Dong, Shah, & Wong (DSW) method to arithmetically add
-    two fuzzy variables together.
+    Add two fuzzy variables together using the restricted DSW method [1]_.
 
     Parameters
     ----------
     x : 1d array
-        Universe for first fuzzy variable
+        Universe for first fuzzy variable.
     mfx : 1d array
-        Fuzzy membership for universe `x`
+        Fuzzy membership for universe ``x``. Must be convex.
     y : 1d array
-        Universe for second fuzzy variable
+        Universe for second fuzzy variable.
     mfy : 1d array
-        Fuzzy membership for universe `y`
+        Fuzzy membership for universe ``y``. Must be convex.
     n : int
-        Number of lambda-cuts to use.
+        Number of lambda-cuts to use; a higher number will have greater
+        resolution toward the limit imposed by input sets ``x`` and ``y``.
 
     Returns
     -------
     z : 1d array
-        Output universe variable
+        Output universe variable.
     mfz : 1d array
-        Output fuzzy membership on universe `z`
+        Output fuzzy membership on universe ``z``.
 
+    Notes
+    -----
+    The Dong, Shah, and Wong (DSW) method requires convex fuzzy membership
+    functions. The ``dsw_*`` functions return results similar to Matplotlib's
+    ``fuzarith`` function.
+
+    References
+    ----------
+    .. [1] W. Dong and H. Shah and F. Wong, Fuzzy computations in risk and
+           decision analysis, Civ Eng Syst, 2, 1985, pp 201-208.
     """
     # Restricted DSW w/n lambda cuts
     x = lambda_cut_series(x, mfx, n)
@@ -115,28 +126,39 @@ def dsw_add(x, mfx, y, mfy, n):
 
 def dsw_div(x, mfx, y, mfy, n):
     """
-    Uses the restricted Dong, Shah, & Wong (DSW) method to arithmetically
-    divide two fuzzy variables, yielding z = x / y.
+    Divide one fuzzy variable by another using the restricted DSW method [1]_.
 
     Parameters
     ----------
     x : 1d array
-        Universe for first fuzzy variable
+        Universe for first fuzzy variable.
     mfx : 1d array
-        Fuzzy membership for universe `x`
+        Fuzzy membership for universe ``x``. Must be convex.
     y : 1d array
-        Universe for second fuzzy variable
+        Universe for second fuzzy variable.
     mfy : 1d array
-        Fuzzy membership for universe `y`
+        Fuzzy membership for universe ``y``. Must be convex.
     n : int
-        Number of lambda-cuts to use.
+        Number of lambda-cuts to use; a higher number will have greater
+        resolution toward the limit imposed by input sets ``x`` and ``y``.
 
     Returns
     -------
     z : 1d array
-        Output universe variable
+        Output universe variable.
     mfz : 1d array
-        Output fuzzy membership on universe `z`
+        Output fuzzy membership on universe ``z``.
+
+    Notes
+    -----
+    The Dong, Shah, and Wong (DSW) method requires convex fuzzy membership
+    functions. The ``dsw_*`` functions return results similar to Matplotlib's
+    ``fuzarith`` function.
+
+    References
+    ----------
+    .. [1] W. Dong and H. Shah and F. Wong, Fuzzy computations in risk and
+           decision analysis, Civ Eng Syst, 2, 1985, pp 201-208.
 
     """
     # Restricted DSW w/n lambda cuts
@@ -163,28 +185,39 @@ def dsw_div(x, mfx, y, mfy, n):
 
 def dsw_mult(x, mfx, y, mfy, n):
     """
-    Uses the restricted Dong, Shah, & Wong (DSW) method to arithmetically
-    multiply two fuzzy variables, i.e. z = x * y.
+    Multiply two fuzzy variables using the restricted DSW method [1]_.
 
     Parameters
     ----------
     x : 1d array
-        Universe for first fuzzy variable
+        Universe for first fuzzy variable.
     mfx : 1d array
-        Fuzzy membership for universe `x`
+        Fuzzy membership for universe ``x``. Must be convex.
     y : 1d array
-        Universe for second fuzzy variable
+        Universe for second fuzzy variable.
     mfy : 1d array
-        Fuzzy membership for universe `y`
+        Fuzzy membership for universe ``y``. Must be convex.
     n : int
-        Number of lambda-cuts to use.
+        Number of lambda-cuts to use; a higher number will have greater
+        resolution toward the limit imposed by input sets ``x`` and ``y``.
 
     Returns
     -------
     z : 1d array
-        Output universe variable
+        Output universe variable.
     mfz : 1d array
-        Output fuzzy membership on universe `z`
+        Output fuzzy membership on universe ``z``.
+
+    Notes
+    -----
+    The Dong, Shah, and Wong (DSW) method requires convex fuzzy membership
+    functions. The ``dsw_*`` functions return results similar to Matplotlib's
+    ``fuzarith`` function.
+
+    References
+    ----------
+    .. [1] W. Dong and H. Shah and F. Wong, Fuzzy computations in risk and
+           decision analysis, Civ Eng Syst, 2, 1985, pp 201-208.
 
     """
     # Restricted DSW w/n lambda cuts
@@ -211,28 +244,40 @@ def dsw_mult(x, mfx, y, mfy, n):
 
 def dsw_sub(x, mfx, y, mfy, n):
     """
-    Uses the restricted Dong, Shah, & Wong (DSW) method to arithmetically
-    divide two fuzzy variables, yielding z = x - y.
+    Subtract a fuzzy variable from another by the restricted DSW method [1]_.
 
     Parameters
     ----------
     x : 1d array
-        Universe for first fuzzy variable
+        Universe for first fuzzy variable.
     mfx : 1d array
-        Fuzzy membership for universe `x`
+        Fuzzy membership for universe ``x``. Must be convex.
     y : 1d array
-        Universe for second fuzzy variable
+        Universe for second fuzzy variable, which will be subtracted from
+        ``x``.
     mfy : 1d array
-        Fuzzy membership for universe `y`
+        Fuzzy membership for universe ``y``. Must be convex.
     n : int
-        Number of lambda-cuts to use.
+        Number of lambda-cuts to use; a higher number will have greater
+        resolution toward the limit imposed by input sets ``x`` and ``y``.
 
     Returns
     -------
     z : 1d array
-        Output universe variable
+        Output universe variable.
     mfz : 1d array
-        Output fuzzy membership on universe `z`
+        Output fuzzy membership on universe ``z``.
+
+    Notes
+    -----
+    The Dong, Shah, and Wong (DSW) method requires convex fuzzy membership
+    functions. The ``dsw_*`` functions return results similar to Matplotlib's
+    ``fuzarith`` function.
+
+    References
+    ----------
+    .. [1] W. Dong and H. Shah and F. Wong, Fuzzy computations in risk and
+           decision analysis, Civ Eng Syst, 2, 1985, pp 201-208.
 
     """
     # Restricted DSW w/n lambda cuts
@@ -299,7 +344,7 @@ def scaleval(q, interval):
     q : float
         Scalar to multiply interval with.
     interval : 1d array, length 2
-        Interval.  Must have exactly two elements.
+        Interval. Must have exactly two elements.
 
     Returns
     -------


### PR DESCRIPTION
Fixes a number of Sphinx reference issues, revise or clarify a few docstrings, and redirect users to the `dsw_*` functions using interval-based arithmetic if the output from `fuzzy_*` mathematics are not expected.