### PR TITLE
DOCFIX: Low/high membership functions transposed.

### DIFF
--- a/docs/examples/plot_tipping_problem.py
+++ b/docs/examples/plot_tipping_problem.py
@@ -41,15 +41,15 @@ x_serv = np.arange(0, 11, 1)
 x_tip  = np.arange(0, 26, 1)
 
 # Generate fuzzy membership functions
-qual_hi = fuzz.trimf(x_qual, [0, 0, 5])
+qual_lo = fuzz.trimf(x_qual, [0, 0, 5])
 qual_md = fuzz.trimf(x_qual, [0, 5, 10])
-qual_lo = fuzz.trimf(x_qual, [5, 10, 10])
-serv_hi = fuzz.trimf(x_serv, [0, 0, 5])
+qual_hi = fuzz.trimf(x_qual, [5, 10, 10])
+serv_lo = fuzz.trimf(x_serv, [0, 0, 5])
 serv_md = fuzz.trimf(x_serv, [0, 5, 10])
-serv_lo = fuzz.trimf(x_serv, [5, 10, 10])
-tip_hi = fuzz.trimf(x_tip, [0, 0, 13])
+serv_hi = fuzz.trimf(x_serv, [5, 10, 10])
+tip_lo = fuzz.trimf(x_tip, [0, 0, 13])
 tip_md = fuzz.trimf(x_tip, [0, 13, 25])
-tip_lo = fuzz.trimf(x_tip, [13, 25, 25])
+tip_hi = fuzz.trimf(x_tip, [13, 25, 25])
 
 # Visualize these universes and membership functions
 fig, (ax0, ax1, ax2) = plt.subplots(nrows=3, figsize=(8, 9))


### PR DESCRIPTION
The example result is the same, but these membership functions were misidentified (which carried through to figure legends).

Hopefully this makes the example easier to follow.