### PR TITLE
Improve Rules API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ docs/source/_static/random.js
 *_build*
 docs/logo/*.png
 docs/source/gitwash
+.idea/

--- a/example.py
+++ b/example.py
@@ -2,7 +2,6 @@ import numpy as np
 import skfuzzy as fuzz
 
 # New Antecedent/Consequent objects hold universe variables and membership functions
-from skfuzzy.control.controlsystem import ControlSystemSimulation
 
 quality = fuzz.Antecedent(np.arange(0, 11, 1), 'quality')
 service = fuzz.Antecedent(np.arange(0, 11, 1), 'service')
@@ -38,7 +37,7 @@ tipping_ctrl = fuzz.ControlSystem([rule1, rule2, rule3])
 # View the whole system
 tipping_ctrl.view()
 
-tipping = ControlSystemSimulation(tipping_ctrl)
+tipping = fuzz.ControlSystemSimulation(tipping_ctrl)
 
 # Pass inputs to the ControlSystem using Antecedent labels with Pythonic API
 # Note: if you like passing many inputs all at once, use .inputs(dict_of_data)
@@ -53,6 +52,7 @@ print tipping.output
 tipping.print_state()
 # Viewing the Consequent again after computation shows the calculated system
 tip.view(sim=tipping)
+quality.view(sim=tipping)
 
 ###############
 # More sophesticated system

--- a/example.py
+++ b/example.py
@@ -52,7 +52,7 @@ tipping.compute()
 print tipping.output
 tipping.print_state()
 # Viewing the Consequent again after computation shows the calculated system
-tip.view()
+tip.view(sim=tipping)
 
 ###############
 # More sophesticated system
@@ -70,8 +70,8 @@ ambiance.automf(3)
 rule4 = fuzz.Rule(service['poor'] & ~decor['good'], ambiance['poor'])
 rule2.view()
 
-# If ambiance is poor, tip is poor
-rule5 = fuzz.Rule(ambiance['poor'], tip['poor'])
+# If ambiance is poor, tip is poor, but at a 75% weight
+rule5 = fuzz.Rule(ambiance['poor'], tip['poor']%.75)
 
 sys2 = fuzz.ControlSystem([rule1, rule4, rule5])
 sys2_sim = ControlSystemSimulation(sys2)

--- a/example.py
+++ b/example.py
@@ -67,7 +67,7 @@ ambiance = fuzz.Intermediary(np.arange(0, 11, 1), 'ambiance')
 ambiance.automf(3)
 
 # If service is poor and decor is not good, ambiance is poor
-rule4 = fuzz.Rule(service['poor'] & decor.not_['good'], ambiance['poor'])
+rule4 = fuzz.Rule(service['poor'] & ~decor['good'], ambiance['poor'])
 rule2.view()
 
 # If ambiance is poor, tip is poor
@@ -80,8 +80,6 @@ sys2_sim.input['service'] = 2.9
 sys2_sim.input['decor'] = 3.5
 sys2_sim.compute()
 
-print sys2_sim.output
-#print ambiance.crisp_value
 sys2.view()
 sys2_sim.print_state()
 

--- a/example.py
+++ b/example.py
@@ -63,7 +63,7 @@ tip.view(sim=tipping)
 decor = fuzz.Antecedent(np.arange(0, 11, 1), 'decor')
 decor.automf(3)
 
-ambiance = fuzz.Intermediary(np.arange(0, 11, 1), 'ambiance')
+ambiance = fuzz.Consequent(np.arange(0, 11, 1), 'ambiance')
 ambiance.automf(3)
 
 # If service is poor and decor is not good, ambiance is poor

--- a/example.py
+++ b/example.py
@@ -25,9 +25,9 @@ tip.view()
 #   * rule1: "If food is poor OR services is poor, then tip will be poor
 #   * rule2: "If service is average, then tip will be average
 #   * rule3: "If service is good OR food is good, then tip will be good
-rule1 = fuzz.Rule([quality['poor'], service['poor']], tip['poor'], kind='or')
+rule1 = fuzz.Rule(quality['poor'] | service['poor'], tip['poor'])
 rule2 = fuzz.Rule(service['average'], tip['average'])
-rule3 = fuzz.Rule([service['good'], quality['good']], tip['good'])
+rule3 = fuzz.Rule(service['good'] | quality['good'], tip['good'])
 
 # Create a new ControlSystem with these rules added
 # Note: it is possible to create an empty ControlSystem() and build it up interactively.
@@ -63,7 +63,7 @@ ambiance = fuzz.Intermediary(np.arange(0, 11, 1), 'ambiance')
 ambiance.automf(3)
 
 # If service is poor and decor is not good, ambiance is poor
-rule4 = fuzz.Rule([service['poor'], decor.not_['good']], ambiance['poor'])
+rule4 = fuzz.Rule(service['poor'] & decor.not_['good'], ambiance['poor'])
 rule2.view()
 
 # If ambiance is poor, tip is poor

--- a/example.py
+++ b/example.py
@@ -2,6 +2,8 @@ import numpy as np
 import skfuzzy as fuzz
 
 # New Antecedent/Consequent objects hold universe variables and membership functions
+from skfuzzy.control.controlsystem import ControlSystemSimulation
+
 quality = fuzz.Antecedent(np.arange(0, 11, 1), 'quality')
 service = fuzz.Antecedent(np.arange(0, 11, 1), 'service')
 tip = fuzz.Consequent(np.arange(0, 26, 1), 'tip')
@@ -31,10 +33,12 @@ rule3 = fuzz.Rule(service['good'] | quality['good'], tip['good'])
 
 # Create a new ControlSystem with these rules added
 # Note: it is possible to create an empty ControlSystem() and build it up interactively.
-tipping = fuzz.ControlSystem([rule1, rule2, rule3])
+tipping_ctrl = fuzz.ControlSystem([rule1, rule2, rule3])
 
 # View the whole system
-tipping.view()
+tipping_ctrl.view()
+
+tipping = ControlSystemSimulation(tipping_ctrl)
 
 # Pass inputs to the ControlSystem using Antecedent labels with Pythonic API
 # Note: if you like passing many inputs all at once, use .inputs(dict_of_data)
@@ -70,14 +74,15 @@ rule2.view()
 rule5 = fuzz.Rule(ambiance['poor'], tip['poor'])
 
 sys2 = fuzz.ControlSystem([rule1, rule4, rule5])
-sys2.input['quality'] = 6.5
-sys2.input['service'] = 2.5
-sys2.input['decor'] = 3.5
-sys2.compute()
+sys2_sim = ControlSystemSimulation(sys2)
+sys2_sim.input['quality'] = 6.5
+sys2_sim.input['service'] = 2.9
+sys2_sim.input['decor'] = 3.5
+sys2_sim.compute()
 
-print sys2.output
-print ambiance.crisp_value
+print sys2_sim.output
+#print ambiance.crisp_value
 sys2.view()
-sys2.print_state()
+sys2_sim.print_state()
 
 a = 5

--- a/example.py
+++ b/example.py
@@ -74,7 +74,7 @@ rule2.view()
 rule5 = fuzz.Rule(ambiance['poor'], tip['poor']%.75)
 
 sys2 = fuzz.ControlSystem([rule1, rule4, rule5])
-sys2_sim = ControlSystemSimulation(sys2)
+sys2_sim = fuzz.ControlSystemSimulation(sys2)
 sys2_sim.input['quality'] = 6.5
 sys2_sim.input['service'] = 2.9
 sys2_sim.input['decor'] = 3.5

--- a/skfuzzy/control/__init__.py
+++ b/skfuzzy/control/__init__.py
@@ -11,4 +11,5 @@ __all__ = ['Antecedent',
            ]
 
 from .antecedent_consequent import Antecedent, Consequent, Intermediary
-from .controlsystem import Rule, ControlSystem
+from .controlsystem import ControlSystem
+from .rule import Rule

--- a/skfuzzy/control/__init__.py
+++ b/skfuzzy/control/__init__.py
@@ -5,11 +5,10 @@ skfuzzy.control subpackage, providing a high-level API for fuzzy system design.
 
 __all__ = ['Antecedent',
            'Consequent',
-           'Intermediary',
            'ControlSystem',
            'Rule',
            ]
 
-from .antecedent_consequent import Antecedent, Consequent, Intermediary
+from .antecedent_consequent import Antecedent, Consequent
 from .controlsystem import ControlSystem
 from .rule import Rule

--- a/skfuzzy/control/__init__.py
+++ b/skfuzzy/control/__init__.py
@@ -6,9 +6,10 @@ skfuzzy.control subpackage, providing a high-level API for fuzzy system design.
 __all__ = ['Antecedent',
            'Consequent',
            'ControlSystem',
+           'ControlSystemSimulation',
            'Rule',
            ]
 
 from .antecedent_consequent import Antecedent, Consequent
-from .controlsystem import ControlSystem
+from .controlsystem import ControlSystem, ControlSystemSimulation
 from .rule import Rule

--- a/skfuzzy/control/antecedent_consequent.py
+++ b/skfuzzy/control/antecedent_consequent.py
@@ -3,7 +3,7 @@ antecedent_consequent.py : Contains Antecedent and Consequent classes.
 """
 import numpy as np
 
-from skfuzzy.control.state import StatefulProperty
+from .state import StatefulProperty
 from ..fuzzymath import interp_membership
 from .fuzzyvariable import FuzzyVariable
 from ..defuzzify import defuzz
@@ -27,11 +27,13 @@ class Antecedent(FuzzyVariable):
         Name of the universe variable.
     """
     # Customized subclass of `FuzzyVariable`
+
+    input = StatefulProperty(None)
+
     def __init__(self, universe, label):
         """""" + Antecedent.__doc__
         super(Antecedent, self).__init__(universe, label)
         self.__name__ = 'Antecedent'
-        self.input = StatefulProperty(None)
 
 
 class Consequent(FuzzyVariable):
@@ -52,11 +54,13 @@ class Consequent(FuzzyVariable):
     Consequents in the ``ControlSystem``.
     """
     # Customized subclass of `FuzzyVariable`
+
+    output = StatefulProperty(None)
+
     def __init__(self, universe, label):
         """""" + Consequent.__doc__
         super(Consequent, self).__init__(universe, label)
         self.__name__ = 'Consequent'
-        self.output = StatefulProperty(None)
 
         # Default accumulation method is to take the max of any cut
         self.accumulation_method = np.max

--- a/skfuzzy/control/antecedent_consequent.py
+++ b/skfuzzy/control/antecedent_consequent.py
@@ -2,6 +2,7 @@
 antecedent_consequent.py : Contains Antecedent and Consequent classes.
 """
 import numpy as np
+import networkx as nx
 
 from .state import StatefulProperty
 from ..fuzzymath import interp_membership
@@ -40,6 +41,13 @@ class Antecedent(FuzzyVariable):
         super(Antecedent, self).__init__(universe, label)
         self.__name__ = 'Antecedent'
 
+    @property
+    def graph(self):
+        g = nx.DiGraph()
+        for t in self.terms.values():
+            g.add_path([self, t])
+        return g
+
 
 class Consequent(FuzzyVariable):
     """
@@ -70,4 +78,9 @@ class Consequent(FuzzyVariable):
         # Default accumulation method is to take the max of any cut
         self.accumulation_method = accu_max
 
-
+    @property
+    def graph(self):
+        g = nx.DiGraph()
+        for t in self.terms.values():
+            g.add_path([t, self])
+        return g

--- a/skfuzzy/control/antecedent_consequent.py
+++ b/skfuzzy/control/antecedent_consequent.py
@@ -14,6 +14,11 @@ except ImportError:
     from .ordereddict import OrderedDict
 
 
+
+def accu_max(*args):
+    return np.max(args)
+
+
 class Antecedent(FuzzyVariable):
     """
     Antecedent (input/sensor) variable for a fuzzy control system.
@@ -63,15 +68,6 @@ class Consequent(FuzzyVariable):
         self.__name__ = 'Consequent'
 
         # Default accumulation method is to take the max of any cut
-        self.accumulation_method = np.max
+        self.accumulation_method = accu_max
 
-
-
-class Intermediary(FuzzyVariable):
-    def __init__(self, universe, label):
-        super(Intermediary, self).__init__(universe, label)
-        self.__name__ = "Intermediary"
-
-        # Default accumulation method to max
-        self.accumulation_method = np.max
 

--- a/skfuzzy/control/antecedent_consequent.py
+++ b/skfuzzy/control/antecedent_consequent.py
@@ -2,6 +2,8 @@
 antecedent_consequent.py : Contains Antecedent and Consequent classes.
 """
 import numpy as np
+
+from skfuzzy.control.state import StatefulProperty
 from ..fuzzymath import interp_membership
 from .fuzzyvariable import FuzzyVariable
 from ..defuzzify import defuzz
@@ -29,18 +31,7 @@ class Antecedent(FuzzyVariable):
         """""" + Antecedent.__doc__
         super(Antecedent, self).__init__(universe, label)
         self.__name__ = 'Antecedent'
-        self._input_set = False
-
-    @property
-    def input(self):
-        if not self._input_set:
-            return None
-        return self.crisp_value
-
-    @input.setter
-    def input(self, value):
-        self.crisp_value = value
-        self._input_set = True
+        self.input = StatefulProperty(None)
 
 
 class Consequent(FuzzyVariable):
@@ -65,17 +56,10 @@ class Consequent(FuzzyVariable):
         """""" + Consequent.__doc__
         super(Consequent, self).__init__(universe, label)
         self.__name__ = 'Consequent'
+        self.output = StatefulProperty(None)
 
         # Default accumulation method is to take the max of any cut
         self.accumulation_method = np.max
-
-    @property
-    def output(self):
-        return self.crisp_value
-
-    @FuzzyVariable.crisp_value.setter
-    def crisp_value(self, value):
-        raise AttributeError("Cannot set the crisp value of a Consequent")
 
 
 

--- a/skfuzzy/control/antecedent_consequent.py
+++ b/skfuzzy/control/antecedent_consequent.py
@@ -66,6 +66,9 @@ class Consequent(FuzzyVariable):
         super(Consequent, self).__init__(universe, label)
         self.__name__ = 'Consequent'
 
+        # Default accumulation method is to take the max of any cut
+        self.accumulation_method = np.max
+
     @property
     def output(self):
         return self.crisp_value
@@ -74,25 +77,6 @@ class Consequent(FuzzyVariable):
     def crisp_value(self, value):
         raise AttributeError("Cannot set the crisp value of a Consequent")
 
-    def set_patch(self, label, cut):
-        """
-        Input method from a fuzzy rule on a consequent membership function.
-
-        Parameters
-        ----------
-        label : string
-            Memebership function the rule is associated with.
-        cut : float
-            Floating-point value from 0 to 1 calculated from current inputs
-            via a fuzzy rule.
-        """
-        if self.terms[label].membership_value is None:
-            self.terms[label].membership_value = cut
-        elif self.terms[label].membership_value < cut:
-            # Update existing cut using an accumulation method
-            #  (this is assuming ACCU = max)
-            # TODO: Multiple accumulation methods
-            self.terms[label].membership_value = cut
 
 
 class Intermediary(FuzzyVariable):
@@ -100,20 +84,6 @@ class Intermediary(FuzzyVariable):
         super(Intermediary, self).__init__(universe, label)
         self.__name__ = "Intermediary"
 
+        # Default accumulation method to max
+        self.accumulation_method = np.max
 
-    def set_patch(self, label, cut):
-        ### Consequent mocking
-        if self.terms[label].membership_value is None:
-            self.terms[label].membership_value = cut
-        elif self.terms[label].membership_value < cut:
-            # Update existing cut using an accumulation method
-            #  (this is assuming ACCU = max)
-            # TODO: Multiple accumulation methods
-            self.terms[label].membership_value = cut
-
-        # Update my crisp value given this new patch
-        output_mf, cut_mfs = self._find_crisp_value()
-        assert len(cut_mfs) > 0
-        crisp = defuzz(self.universe, output_mf, self.defuzzify_method)
-        self.crisp_value = crisp
-        print "%s is now %s" % (self, crisp)

--- a/skfuzzy/control/controlsystem.py
+++ b/skfuzzy/control/controlsystem.py
@@ -19,180 +19,6 @@ except ImportError:
     from .ordereddict import OrderedDict
 
 
-class OLD_Rule(object):
-    """
-    Define a new fuzzzy rule relating universe variables in memory.
-
-    Parameters
-    ----------
-    antecedents : Antecedent or iterable of Antecedents
-        Fuzzy antecedents (input/sensors) as from ``skfuzzy.Antecedent``.
-    consequents : Consequent or iterable of Consequents
-        Fuzzy consequents (output/control) as from ``skfuzzy.Consequent``.
-        Universe variable for the fuzzy consequent.
-    kind : string
-        Defines the relationship of antecedents. 'or' will combine with a
-        maximum operator, while 'and' will combine with a minimum operator.
-
-    Notes
-    -----
-    Boolean logic order of operations (NOT > AND > OR) is followed.
-    """
-
-    def __init__(self, antecedents=None, consequents=None, kind='or',
-                 label=None):
-        self._chk_kind(kind)
-        self.kind = kind.lower()
-        self.antecedents = self._chk_obj(antecedents, Antecedent)
-        self.consequents = self._chk_obj(consequents, Consequent)
-        self.label = label
-        self.graph = nx.DiGraph()
-        self.graph.add_node(self)
-        self.graph.node[self]['kind'] = kind
-        self._id = id(self)
-
-        # Debugging state
-        self.collected_firing = {}
-        self.final_firing = None
-
-        if antecedents is None or consequents is None:
-            self.connections = None
-        else:
-            self._connect(antecedents, consequents, kind)
-
-    def __repr__(self):
-        """
-        Print a concise, readable summary of the fuzzy rule.
-        """
-        if self.label is not None:
-            return self.label
-        # All this for a pretty printed representation of the rule...
-        antlen = len(self.antecedents)
-        conlen = len(self.consequents)
-
-        ant_str = ''
-        con_str = ''
-
-        for antecedent in self.antecedents:
-            ant_str += antecedent.full_label + ', '
-
-        for consequent in self.consequents:
-            con_str += consequent.full_label + ', '
-
-        ant_str = ant_str[:-2]
-        con_str = con_str[:-2]
-
-        if antlen > 1:
-            ant_str = '[' + ant_str + ']'
-
-        if conlen > 1:
-            con_str = '[' + con_str + ']'
-
-        return "{0}-Rule connecting {1} with {2}".format(
-            self.kind.upper(), ant_str, con_str)
-
-    def _chk_obj(self, var, obj):
-        """
-        Argument checking to ensure every adjective's parent is type ``obj``.
-        """
-        temp = self._iter(var)
-        for term in temp:
-            parent = term.parent_variable
-            if not isinstance(term, FuzzyVariableTerm):
-                raise ValueError("All elements must be terms")
-            if parent is None:
-                raise ValueError("All terms must have a parent")
-            if not isinstance(parent, obj):
-                raise ValueError("All term's variables must be of type "
-                                 "{0}".format(obj))
-        return temp
-
-    def _iter(self, var):
-        """
-        Ensure a variable is iterable; wrap in a list if necessary.
-        """
-        if issubclass(var.__class__, FuzzyVariableTerm):
-            return [var, ]
-        else:
-            return var
-
-    def _chk_kind(self, string):
-        """
-        The only accepted kinds of fuzzy rules are 'or', or 'and'.
-        """
-        string = string.lower()
-        if string == 'or' or string == 'and':
-            return
-        else:
-            raise ValueError("Incorrect kind. Options are 'or' or 'and'.")
-
-    def add_antecedent(self, antecedent_term):
-        """
-        Populate the graph with a new antecedent, connecting it to this rule.
-        """
-        assert isinstance(antecedent_term, FuzzyVariableTerm)
-        antecedent = antecedent_term.parent_variable
-        assert isinstance(antecedent, Antecedent)
-
-        # Antecedent -> Antecedent_Term -> Rule
-        self.graph.add_path([antecedent, antecedent_term])
-        self.graph.add_path([antecedent_term, self])
-
-
-    def add_consequent(self, consequent_term):
-        """
-        Populate the graph with a new consequent, connecting it to this rule.
-        """
-        assert isinstance(consequent_term, FuzzyVariableTerm)
-        consequent = consequent_term.parent_variable
-        assert isinstance(consequent, Consequent)
-
-        # Rule -> Consequent_Term -> Consequent
-        self.graph.add_path([self, consequent_term])
-        self.graph.add_path([consequent_term, consequent])
-
-
-
-    def _connect(self, antecedents=None, consequents=None, kind='or'):
-        """
-        Private method used when arguments provided on rule instantiation.
-        """
-        for antecedent in self.antecedents:
-            self.add_antecedent(antecedent)
-
-        for consequent in self.consequents:
-            self.add_consequent(consequent)
-
-    def compute(self):
-        """
-        Execute this fuzzy rule.
-        """
-
-        # Collect the firing of all input membership functions
-        self.collected_firing = {}
-        for antecedent_term in self.graph.predecessors(self):
-            mv = antecedent_term.membership_value
-            if mv is None:
-                raise Exception("Membership value missing for " +
-                                antecedent_term.full_label)
-            self.collected_firing[antecedent_term.full_label] = mv
-
-        # Combine membership function firing as appropriate for this rule
-        if self.kind == 'or':
-            self.final_firing = np.asarray(self.collected_firing.values()).max()
-        elif self.kind == 'and':
-            self.final_firing = np.asarray(self.collected_firing.values()).min()
-        else:
-            raise NotImplementedError("Unexpected kind: " + self.kind)
-
-        # Cap output membership function(s) in consequents
-        for consequent_term in self.graph.successors(self):
-            consequent_term.parent_variable.set_patch(
-                consequent_term.label, self.final_firing)
-
-    def view(self):
-        ControlSystemVisualizer(self).view().show()
-
 class ControlSystem(object):
     """
     Fuzzy Control System
@@ -263,17 +89,34 @@ class _InputAcceptor(object):
         if len(matches) == 0:
             raise ValueError("Unexpected input: " + key)
         assert len(matches) == 1
-        matches[0].input[self.sim] = value
+        var = matches[0]
+
+        if value > max(var.universe):
+            if self.sim.clip_to_bounds:
+                value = max(var.universe)
+            else:
+                raise ValueError("Value is out of bounds.  Max is %s" %
+                                 max(var.universe))
+        if value < min(var.universe):
+            if self.sim.clip_to_bounds:
+                value = min(var.universe)
+            else:
+                raise ValueError("Value is out of bounds.  Min is %s" %
+                                 min(var.universe))
+
+        var.input[self.sim] = value
 
 
 class ControlSystemSimulation(object):
 
-    def __init__(self, control_system):
+    def __init__(self, control_system, clip_to_bounds = False):
         assert isinstance(control_system, ControlSystem)
         self.ctrl = control_system
 
         self.input = _InputAcceptor(self)
         self.output = OrderedDict()
+
+        self.clip_to_bounds = clip_to_bounds
 
     def inputs(self, input_dict):
         """

--- a/skfuzzy/control/controlsystem.py
+++ b/skfuzzy/control/controlsystem.py
@@ -352,8 +352,9 @@ class ControlSystemSimulation(object):
 
         # Collect the results and present them as a dict
         for consequent in self.ctrl.consequents:
-            CrispValueCalculator(consequent, self).defuzz()
-            self.output[consequent.label] = consequent.output
+            consequent.output[self] = \
+                CrispValueCalculator(consequent, self).defuzz()
+            self.output[consequent.label] = consequent.output[self]
 
     def compute_rule(self, rule):
         """
@@ -361,7 +362,6 @@ class ControlSystemSimulation(object):
         Mamdani inference: Aggregation, activation, and accumulation
 
         """
-        print "EVALUATING %s" % rule
         # Step 1: Aggregation.  This finds the net accomplishment of the
         #  antecedent by AND-ing or OR-ing together all the membership values
         #  of the terms that make up the accomplishment condition.

--- a/skfuzzy/control/controlsystem.py
+++ b/skfuzzy/control/controlsystem.py
@@ -378,8 +378,6 @@ class ControlSystemSimulation(object):
         #  be if the consequent has a weight, which we would apply now.
         for c in rule.consequent:
             assert isinstance(c, WeightedConsequent)
-            print "RULE", rule
-            print "FIRE", rule.aggregate_firing[self]
             c.activation[self] = rule.aggregate_firing[self] * c.weight
 
         # Step 3: Accumulation.  Apply the activation to each consequent,

--- a/skfuzzy/control/fuzzyvariable.py
+++ b/skfuzzy/control/fuzzyvariable.py
@@ -77,6 +77,11 @@ class FuzzyVariableTerm(TermPrimitive):
     def __invert__(self):
         return FuzzyVariableTermAggregate(self, None, 'not')
 
+    def __mod__(self, other):
+        from .rule import WeightedConsequent
+        assert isinstance(other, float)
+        return WeightedConsequent(self, other)
+
 
 class FuzzyAggregationMethod(object):
     def __init__(self, and_func=min, or_func=max):

--- a/skfuzzy/control/fuzzyvariable.py
+++ b/skfuzzy/control/fuzzyvariable.py
@@ -6,7 +6,7 @@ import networkx as nx
 import matplotlib.pyplot as plt
 
 from skfuzzy import defuzz, interp_membership
-from skfuzzy.control.state import StatefulProperty
+from skfuzzy.control.state import StatefulProperty, StatefulProperty
 from ..membership import trimf
 from .visualization import FuzzyVariableVisualizer
 
@@ -31,14 +31,15 @@ class FuzzyVariableTerm(TermPrimitive):
     and good.
     """
 
+    # State variables
+    membership_value = StatefulProperty(None)
+    cuts = StatefulProperty({})
+
     def __init__(self, label, membership_function):
         super(FuzzyVariableTerm, self).__init__()
         self.label = label
         self.parent_variable = None
         self.mf = membership_function
-
-        self.membership_value = StatefulProperty(None)
-        self.cuts = StatefulProperty({})
 
     @property
     def full_label(self):
@@ -60,16 +61,14 @@ class FuzzyVariableTerm(TermPrimitive):
         return self.full_label
 
     def __and__(self, other):
-        if not (isinstance(other, FuzzyVariableTerm) \
-                or isinstance(other, FuzzyVariableTermAggregate)):
+        if not isinstance(other, TermPrimitive):
             raise ValueError("Can only construct 'AND' from the term "
                              "of a fuzzy variable")
 
         return FuzzyVariableTermAggregate(self, other, 'and')
 
     def __or__(self, other):
-        if not (isinstance(other, FuzzyVariableTerm) \
-                or isinstance(other, FuzzyVariableTermAggregate)):
+        if not isinstance(other, TermPrimitive):
             raise ValueError("Can only construct 'OR' from the term "
                              "of a fuzzy variable")
 

--- a/skfuzzy/control/rule.py
+++ b/skfuzzy/control/rule.py
@@ -6,7 +6,7 @@ atecedents with conqeuents in a `ControlSystem`.
 import numpy as np
 import networkx as nx
 from weakref import WeakKeyDictionary
-from .antecedent_consequent import Antecedent, Consequent, Intermediary
+from .antecedent_consequent import Antecedent, Consequent
 from .fuzzyvariable import (FuzzyVariable, FuzzyVariableTerm,
                             FuzzyAggregationMethod,
                             FuzzyVariableTermAggregate, TermPrimitive)

--- a/skfuzzy/control/rule.py
+++ b/skfuzzy/control/rule.py
@@ -32,7 +32,7 @@ class WeightedConsequent(object):
         if self.weight == 1.:
             return self.term.full_label
         else:
-            return "%s@%02.f" % (self.term.full_label, self.weight)
+            return "%s@%0.2f%%" % (self.term.full_label, self.weight)
 
 
 class Rule(object):
@@ -105,14 +105,17 @@ class Rule(object):
          a) Unweighted single output.
             eg: output['term']
          b) Weighted single output
-            eg: (output['term'], 0.5)
+            eg: (output['term']%0.5)
          c) Unweighted multiple output
             eg: (output1['term1'], output2['term2'])
          d) Weighted multiple output
-            eg: ( (output1['term1'],1.0), (output2['term2'],0.5) )
+            eg: ( (output1['term1']%1.0), (output2['term2']%0.5) )
         """
         if isinstance(value, FuzzyVariableTerm):
             self._consequent = [WeightedConsequent(value, 1.)]
+
+        elif isinstance(value, WeightedConsequent):
+            self._consequent = [value]
 
         elif not hasattr(value, '__iter__'):
             raise ValueError("Unexpected consequent type")
@@ -124,13 +127,10 @@ class Rule(object):
             for i in value:
                 if isinstance(i, FuzzyVariableTerm):
                     self._consequent.append(WeightedConsequent(i, 1.))
+                elif isinstance(i, WeightedConsequent):
+                    self._consequent.append(i)
                 else:
-                    try:
-                        assert len(i) == 2
-                    except:
-                        # Could die to assertion or because i is not iterable
-                        raise ValueError("Unexpected consequent type")
-                    self._consequent.append((WeightedConsequent(i[0], i[1])))
+                    raise ValueError("Unexpected consequent type")
 
     @property
     def graph(self):

--- a/skfuzzy/control/rule.py
+++ b/skfuzzy/control/rule.py
@@ -9,7 +9,7 @@ from weakref import WeakKeyDictionary
 from .antecedent_consequent import Antecedent, Consequent, Intermediary
 from .fuzzyvariable import (FuzzyVariable, FuzzyVariableTerm,
                             FuzzyAggregationMethod,
-                            FuzzyVariableTermAggregate)
+                            FuzzyVariableTermAggregate, TermPrimitive)
 from .visualization import ControlSystemVisualizer
 from .state import StatefulProperty
 
@@ -68,11 +68,12 @@ class Rule(object):
         return self._antecedent
     @antecedent.setter
     def antecedent(self, value):
-        if hasattr(value, 'membership_value'):
-            # Should be either FuzzyVariableTerm or FuzzyVariableTermAggregate
-            self._antecedent = value
-        else:
+        if not isinstance(value, TermPrimitive):
             raise ValueError("Unexpected antecedent type")
+        # Should be either FuzzyVariableTerm or FuzzyVariableTermAggregate
+        self._antecedent = value
+
+
 
     @property
     def antecedent_terms(self):
@@ -81,6 +82,8 @@ class Rule(object):
         def _find_terms(obj):
             if isinstance(obj, FuzzyVariableTerm):
                 terms.append(obj)
+            elif obj is None:
+                pass
             else:
                 assert isinstance(obj, FuzzyVariableTermAggregate)
                 _find_terms(obj.term1)

--- a/skfuzzy/control/rule.py
+++ b/skfuzzy/control/rule.py
@@ -140,12 +140,13 @@ class Rule(object):
         for t in self.antecedent_terms:
             assert isinstance(t, FuzzyVariableTerm)
             graph.add_path([t, self])
-            graph.add_path([t.parent_variable, t])
+            graph = nx.compose(graph, t.parent_variable.graph)
 
         # Link all consequents from me
         for c in self.consequent:
+            assert isinstance(c, WeightedConsequent)
             graph.add_path([self, c.term])
-            graph.add_path([c.term, c.term.parent_variable])
+            graph = nx.compose(graph, c.term.parent_variable.graph)
         return graph
 
 

--- a/skfuzzy/control/rule.py
+++ b/skfuzzy/control/rule.py
@@ -1,0 +1,179 @@
+"""
+rule.py : Contains `Rule` object which is used to connected
+atecedents with conqeuents in a `ControlSystem`.
+"""
+
+import numpy as np
+import networkx as nx
+from weakref import WeakKeyDictionary
+from .antecedent_consequent import Antecedent, Consequent, Intermediary
+from .fuzzyvariable import (FuzzyVariable, FuzzyVariableTerm,
+                            FuzzyAggregationMethod,
+                            FuzzyVariableTermAggregate)
+from .visualization import ControlSystemVisualizer
+
+try:
+    from collections import OrderedDict
+except ImportError:
+    from .ordereddict import OrderedDict
+
+
+class WeightedConsequent(object):
+    def __init__(self, term, weight):
+        assert isinstance(term, FuzzyVariableTerm)
+        self.term = term
+        self.weight = weight
+        self.activation = None
+
+    def __repr__(self):
+        if self.weight == 1.:
+            return self.term.full_label
+        else:
+            return "%s@%02.f" % (self.term.full_label, self.weight)
+
+
+class Rule(object):
+
+    def __init__(self, antecedent=None, consequent=None, label=None):
+        self.label = label
+        self._antecedent = None
+        self._consequent = None
+
+        self.aggregation_method = FuzzyAggregationMethod()
+        self.aggregate_firing = None
+
+        if antecedent is not None:
+            self.antecedent = antecedent
+        if consequent is not None:
+            self.consequent = consequent
+
+
+    def __repr__(self):
+        """
+        Print a concise, readable summary of the fuzzy rule.
+        """
+        if self.label is not None:
+            return self.label
+        if len(self.consequent) == 1:
+            cons = self.consequent[0]
+        else:
+            cons = self.consequent
+        return "IF %s THEN %s" % (self.antecedent, cons)
+
+    @property
+    def antecedent(self):
+        if self._antecedent is None:
+            raise ValueError("Antecedent not set")
+        return self._antecedent
+    @antecedent.setter
+    def antecedent(self, value):
+        if hasattr(value, 'membership_value'):
+            # Should be either FuzzyVariableTerm or FuzzyVariableTermAggregate
+            self._antecedent = value
+        else:
+            raise ValueError("Unexpected antecedent type")
+
+    @property
+    def antecedent_terms(self):
+        # Grab all the terms that make up my antecedent clause
+        terms = []
+        def _find_terms(obj):
+            if isinstance(obj, FuzzyVariableTerm):
+                terms.append(obj)
+            else:
+                assert isinstance(obj, FuzzyVariableTermAggregate)
+                _find_terms(obj.term1)
+                _find_terms(obj.term2)
+        _find_terms(self.antecedent)
+        return terms
+
+    @property
+    def consequent(self):
+        if self._consequent is None:
+            raise ValueError("Consquent not set")
+        return self._consequent
+    @consequent.setter
+    def consequent(self, value):
+        """
+        Accepts consequents in four formats:
+         a) Unweighted single output.
+            eg: output['term']
+         b) Weighted single output
+            eg: (output['term'], 0.5)
+         c) Unweighted multiple output
+            eg: (output1['term1'], output2['term2'])
+         d) Weighted multiple output
+            eg: ( (output1['term1'],1.0), (output2['term2'],0.5) )
+        """
+        if isinstance(value, FuzzyVariableTerm):
+            self._consequent = [WeightedConsequent(value, 1.)]
+
+        elif not hasattr(value, '__iter__'):
+            raise ValueError("Unexpected consequent type")
+
+        else:
+
+            # Must be one of formats b) to d)
+            self._consequent = []
+            for i in value:
+                if isinstance(i, FuzzyVariableTerm):
+                    self._consequent.append(WeightedConsequent(i, 1.))
+                else:
+                    try:
+                        assert len(i) == 2
+                    except:
+                        # Could die to assertion or because i is not iterable
+                        raise ValueError("Unexpected consequent type")
+                    self._consequent.append((WeightedConsequent(i[0], i[1])))
+
+    @property
+    def graph(self):
+        graph = nx.DiGraph()
+        # Link all antecedents to me by decomposing
+        #  FuzzyVariableTermAggregate down to just FuzzyVariableTerms
+        for t in self.antecedent_terms:
+            assert isinstance(t, FuzzyVariableTerm)
+            graph.add_path([t, self])
+            graph.add_path([t.parent_variable, t])
+
+        # Link all consequents from me
+        for c in self.consequent:
+            graph.add_path([self, c.term])
+            graph.add_path([c.term, c.term.parent_variable])
+        return graph
+
+    def compute(self):
+        """
+        Implements rule according to the three step method of
+        Mamdani inference: Aggregation, activation, and accumulation
+
+        """
+        # Step 1: Aggregation.  This finds the net accomplishment of the
+        #  antecedent by AND-ing or OR-ing together all the membership values
+        #  of the terms that make up the accomplishment condition.
+        #  The process of actually aggregating everything is delegated to the
+        #  FuzzyVariableTermAggregation class, but we can tell that class
+        #  what aggregation style this rule mandates
+
+        if isinstance(self.antecedent, FuzzyVariableTermAggregate):
+            self.antecedent.agg_method = self.aggregation_method
+        self.aggregate_firing = self.antecedent.membership_value
+
+        # Step 2: Activation.  The degree of membership of the consequence
+        #  is determined by the degree of accomplishment of the antecedent,
+        #  which is what we determined in step 1.  The only difference would
+        #  be if the consequent has a weight, which we would apply now.
+        for c in self.consequent:
+            assert isinstance(c, WeightedConsequent)
+            c.activation = self.aggregate_firing * c.weight
+
+        # Step 3: Accumulation.  Apply the activation to each consequent,
+        #   accumulating multiple rule firings into a single membership value.
+        #   The process of actual accumulation is delegated to the
+        #   FuzzyVariableTerm which uses its parent's accumulation method
+        for c in self.consequent:
+            assert isinstance(c, WeightedConsequent)
+            c.term.accumulate_cut(self, c.activation)
+
+    def view(self):
+        ControlSystemVisualizer(self).view().show()

--- a/skfuzzy/control/rule.py
+++ b/skfuzzy/control/rule.py
@@ -11,7 +11,7 @@ from .fuzzyvariable import (FuzzyVariable, FuzzyVariableTerm,
                             FuzzyAggregationMethod,
                             FuzzyVariableTermAggregate, TermPrimitive)
 from .visualization import ControlSystemVisualizer
-from .state import StatefulProperty
+from .state import StatefulProperty, StatefulProperty
 
 try:
     from collections import OrderedDict
@@ -20,11 +20,13 @@ except ImportError:
 
 
 class WeightedConsequent(object):
+
+    activation = StatefulProperty(None)
+
     def __init__(self, term, weight):
         assert isinstance(term, FuzzyVariableTerm)
         self.term = term
         self.weight = weight
-        self.activation = StatefulProperty(None)
 
     def __repr__(self):
         if self.weight == 1.:
@@ -35,11 +37,11 @@ class WeightedConsequent(object):
 
 class Rule(object):
 
+    aggregate_firing = StatefulProperty(None)
+
     def __init__(self, antecedent=None, consequent=None, label=None):
         self.label = label
         self.aggregation_method = FuzzyAggregationMethod()
-
-        self.aggregate_firing = StatefulProperty(None)
 
         self._antecedent = None
         self._consequent = None

--- a/skfuzzy/control/state.py
+++ b/skfuzzy/control/state.py
@@ -51,7 +51,4 @@ class StatePerSimulation(object):
         assert isinstance(key, ControlSystemSimulation)
         self.__sim_data[key] = value
 
-    def __del__(self):
-        # For debugging
-        raise RuntimeError("Tried to delete a stateful property!")
 

--- a/skfuzzy/control/state.py
+++ b/skfuzzy/control/state.py
@@ -1,0 +1,36 @@
+
+from weakref import WeakKeyDictionary
+
+
+
+
+class StatefulProperty(object):
+
+    def __init__(self, initial_condition = None):
+        self.default = initial_condition
+        self.__sim_data = WeakKeyDictionary()
+
+    def __getitem__(self, key):
+        from .controlsystem import ControlSystemSimulation
+        assert isinstance(key, ControlSystemSimulation)
+        try:
+            return self.__sim_data[key]
+        except KeyError:
+            if isinstance(self.default, dict) and len(self.default) == 0:
+                # Create a new empty dictionary and remember it
+                result = dict()
+                self.__sim_data[key] = result
+                return result
+            else:
+                return self.default
+
+
+    def __setitem__(self, key, value):
+        from .controlsystem import ControlSystemSimulation
+        assert isinstance(key, ControlSystemSimulation)
+        self.__sim_data[key] = value
+
+    def __del__(self):
+        # For debugging
+        raise RuntimeError("Tried to delete a stateful property!")
+

--- a/skfuzzy/control/state.py
+++ b/skfuzzy/control/state.py
@@ -2,9 +2,30 @@
 from weakref import WeakKeyDictionary
 
 
-
-
 class StatefulProperty(object):
+
+    def __init__(self, initial_condition = None):
+        self.default = initial_condition
+        self.data = WeakKeyDictionary()
+
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+
+        try:
+            return self.data[instance]
+        except KeyError:
+            val = StatePerSimulation(self.default)
+            self.data[instance] = val
+            return val
+
+    def __set__(self, instance, value):
+        raise AttributeError("Property is read-only. "
+                             "Did you mean to access via a simultation?")
+
+
+
+class StatePerSimulation(object):
 
     def __init__(self, initial_condition = None):
         self.default = initial_condition

--- a/skfuzzy/control/state.py
+++ b/skfuzzy/control/state.py
@@ -29,18 +29,18 @@ class StatePerSimulation(object):
 
     def __init__(self, initial_condition = None):
         self.default = initial_condition
-        self.__sim_data = WeakKeyDictionary()
+        self._sim_data = WeakKeyDictionary()
 
     def __getitem__(self, key):
         from .controlsystem import ControlSystemSimulation
         assert isinstance(key, ControlSystemSimulation)
         try:
-            return self.__sim_data[key]
+            return self._sim_data[key]
         except KeyError:
             if isinstance(self.default, dict) and len(self.default) == 0:
                 # Create a new empty dictionary and remember it
                 result = dict()
-                self.__sim_data[key] = result
+                self._sim_data[key] = result
                 return result
             else:
                 return self.default
@@ -49,6 +49,6 @@ class StatePerSimulation(object):
     def __setitem__(self, key, value):
         from .controlsystem import ControlSystemSimulation
         assert isinstance(key, ControlSystemSimulation)
-        self.__sim_data[key] = value
+        self._sim_data[key] = value
 
 

--- a/skfuzzy/control/tests/test_controlsystem.py
+++ b/skfuzzy/control/tests/test_controlsystem.py
@@ -1,8 +1,11 @@
 import numpy as np
 import numpy.testing as tst
+import nose
 
-from skfuzzy.control import Antecedent, Consequent, Rule, ControlSystem
+from skfuzzy.control import (Antecedent, Consequent, Rule, ControlSystem,
+                             ControlSystemSimulation)
 from skfuzzy import trimf
+from nose.tools import assert_raises
 
 
 def test_tipping_problem():
@@ -20,9 +23,9 @@ def test_tipping_problem():
     tip['lots'] = trimf(tip.universe, [13, 25, 25])
 
     # Define fuzzy rules
-    rule1 = Rule([food['poor'], service['poor']], tip['bad'], kind='or')
+    rule1 = Rule(food['poor'] | service['poor'], tip['bad'])
     rule2 = Rule(service['average'], tip['middling'])
-    rule3 = Rule([service['good'], food['good']], tip['lots'])
+    rule3 = Rule(service['good'] | food['good'], tip['lots'])
 
     # The control system - defined both possible ways
     tipping = ControlSystem([rule1, rule2, rule3])
@@ -32,24 +35,66 @@ def test_tipping_problem():
     tipping2.addrule(rule3)
     tipping2.addrule(rule1)
 
+    tip_sim = ControlSystemSimulation(tipping)
+    tip_sim2 = ControlSystemSimulation(tipping2)
+
     # Inputs added both possible ways
     inputs = {'quality': 6.5, 'service': 9.8}
     for key, value in inputs.items():
-        tipping.input[key] = value
+        tip_sim.input[key] = value
 
-    tipping2.inputs(inputs)
+    tip_sim2.inputs(inputs)
 
     # Compute the system
-    tipping.compute()
-    tipping2.compute()
+    tip_sim.compute()
+    tip_sim2.compute()
 
-    assert tipping.output == tipping2.output
-    tst.assert_allclose(tipping.output['tip'], 20.244508118433625)
+    assert tip_sim.output == tip_sim2.output
+    tst.assert_allclose(tip_sim.output['tip'], 20.244508118433625)
 
 
 def test_bad_rules():
     not_rules = ['me', 192238, 42, dict()]
     tst.assert_raises(ValueError, ControlSystem, not_rules)
+
+def setup_rule_order():
+    global a, b, c, d
+    a = Antecedent(np.linspace(0, 10, 11), 'a')
+    b = Antecedent(np.linspace(0, 10, 11), 'b')
+    c = Antecedent(np.linspace(0, 10, 11), 'c')
+    d = Antecedent(np.linspace(0, 10, 11), 'd')
+
+    for v in (a,b,c,d):
+        v.automf(3)
+
+@nose.with_setup(setup_rule_order)
+def test_rule_order():
+    # Make sure rules are exposed in the order needed to solve them
+    #  correctly
+    global a, b, c, d
+
+    r1 = Rule(a['average'] | a['poor'], c['poor'], label='r1')
+    r2 = Rule(c['poor'] | b['poor'], c['good'], label='r2')
+    r3 = Rule(c['good'] | a['good'], d['good'], label='r3')
+
+    ctrl = ControlSystem([r1, r2, r3])
+    resolved = list(ctrl.rules)
+    assert resolved == [r1, r2, r3], "Order given was: %s" % resolved
+
+@nose.with_setup(setup_rule_order)
+def test_unresolvable_rule_order():
+    # Make sure we don't get suck in an infinite loop when the user
+    #  gives an unresolvable rule order
+    global a, b, c, d
+
+    r1 = Rule(a['average'] | a['poor'], c['poor'], label='r1')
+    r2 = Rule(c['poor'] | b['poor'], c['poor'], label='r2')
+    r3 = Rule(c['good'] | a['good'], d['good'], label='r3')
+
+    ctrl = ControlSystem([r1, r2, r3])
+    ex_msg = "Unable to resolve rule execution order"
+    with assert_raises(RuntimeError, expected_regexp=ex_msg):
+        list(ctrl.rules)
 
 if __name__ == '__main__':
     tst.run_module_suite()

--- a/skfuzzy/control/tests/test_fuzzyvariables.py
+++ b/skfuzzy/control/tests/test_fuzzyvariables.py
@@ -321,9 +321,9 @@ def test_cannot_compute():
     global ant
     global con
     with tst.assert_raises(ValueError):
-        ant.crisp_value
+        ant.input
     with tst.assert_raises(ValueError):
-        con.crisp_value
+        con.output
 
 
 if __name__ == '__main__':

--- a/skfuzzy/control/visualization.py
+++ b/skfuzzy/control/visualization.py
@@ -67,6 +67,8 @@ class FuzzyVariableVisualizer(object):
             if crisp_value is not None:
                 y = interp_membership(self.fuzzy_var.universe,
                                       output_mf, crisp_value)
+                # Small values are hard to see, so simply set them to 1 so
+                #  we can see them
                 if y < 0.1:
                     y = 1.
                 self.ax.plot([crisp_value] * 2, [0, y],

--- a/skfuzzy/control/visualization.py
+++ b/skfuzzy/control/visualization.py
@@ -27,20 +27,21 @@ class FuzzyVariableVisualizer(object):
         self.fig, self.ax = plt.subplots()
         self.plots = {}
 
-    def view(self, *args, **kwargs):
+    def view(self, sim=None, *args, **kwargs):
         """
         Visualize this variable and its membership functions with Matplotlib.
         Additionally, show the current output membership functions.
         """
+        from .controlsystem import (CrispValueCalculator, ControlSystem,
+                                    ControlSystemSimulation)
+        if sim is None:
+            # Create an empty simulation so we can view with default values
+            sim = ControlSystemSimulation(ControlSystem())
 
         self._init_plot()
 
-        from .controlsystem import (CrispValueCalculator, ControlSystemSimulation,
-                                    ControlSystem)
-
-        crispy = CrispValueCalculator(self.fuzzy_var,
-                                      ControlSystemSimulation(ControlSystem()))
-        output_mf, cut_mfs = crispy.find_crisp_value()
+        crispy = CrispValueCalculator(self.fuzzy_var, sim)
+        output_mf, cut_mfs = crispy.find_memberships()
 
         # Plot the output membership functions
         cut_plots = {}
@@ -62,6 +63,8 @@ class FuzzyVariableVisualizer(object):
             if crip_value is not None:
                 y = interp_membership(self.fuzzy_var.universe,
                                       output_mf, crip_value)
+                if y < 0.1:
+                    y = 1.
                 self.ax.plot([crip_value] * 2, [0, y],
                               color='k', lw=3, label='crisp value')
 

--- a/skfuzzy/control/visualization.py
+++ b/skfuzzy/control/visualization.py
@@ -56,23 +56,27 @@ class FuzzyVariableVisualizer(object):
                     self.fuzzy_var.universe, zeros, cut_mfs[label],
                     facecolor=color, alpha=0.4)
 
-        # Plot defuzzified output if available
+        # Plot crisp value if available
         if len(cut_mfs) > 0 and not all(output_mf == 0):
-            crip_value = defuzz(self.fuzzy_var.universe, output_mf,
-                                self.fuzzy_var.defuzzify_method)
-            if crip_value is not None:
+            crisp_value = None
+            if hasattr(self.fuzzy_var, 'input'):
+                crisp_value = self.fuzzy_var.input[sim]
+            elif hasattr(self.fuzzy_var, 'output'):
+                crisp_value = self.fuzzy_var.output[sim]
+
+            if crisp_value is not None:
                 y = interp_membership(self.fuzzy_var.universe,
-                                      output_mf, crip_value)
+                                      output_mf, crisp_value)
                 if y < 0.1:
                     y = 1.
-                self.ax.plot([crip_value] * 2, [0, y],
+                self.ax.plot([crisp_value] * 2, [0, y],
                               color='k', lw=3, label='crisp value')
 
         return self.fig
 
     def _init_plot(self):
         # Formatting: limits
-        self.ax.set_ylim([0, 1])
+        self.ax.set_ylim([0, 1.01])
         self.ax.set_xlim([self.fuzzy_var.universe.min(),
                      self.fuzzy_var.universe.max()])
 

--- a/skfuzzy/control/visualization.py
+++ b/skfuzzy/control/visualization.py
@@ -4,7 +4,9 @@ visualization.py : Contains classes to help with visualizing a control system
 import numpy as np
 import networkx as nx
 import matplotlib.pyplot as plt
+
 from .. import defuzz, interp_membership
+
 
 class FuzzyVariableVisualizer(object):
 
@@ -33,7 +35,12 @@ class FuzzyVariableVisualizer(object):
 
         self._init_plot()
 
-        output_mf, cut_mfs = self.fuzzy_var._find_crisp_value()
+        from .controlsystem import (CrispValueCalculator, ControlSystemSimulation,
+                                    ControlSystem)
+
+        crispy = CrispValueCalculator(self.fuzzy_var,
+                                      ControlSystemSimulation(ControlSystem()))
+        output_mf, cut_mfs = crispy.find_crisp_value()
 
         # Plot the output membership functions
         cut_plots = {}

--- a/skfuzzy/control/visualization.py
+++ b/skfuzzy/control/visualization.py
@@ -57,7 +57,7 @@ class FuzzyVariableVisualizer(object):
                     facecolor=color, alpha=0.4)
 
         # Plot defuzzified output if available
-        if len(cut_mfs) > 0:
+        if len(cut_mfs) > 0 and not all(output_mf == 0):
             crip_value = defuzz(self.fuzzy_var.universe, output_mf,
                                 self.fuzzy_var.defuzzify_method)
             if crip_value is not None:


### PR DESCRIPTION
This is an improvement to the rules API to use operators for rules:
- `&` for and
- `|` for or
- `~` for not

I've tested it with some pretty complex logic and it seems to work well.  This isn't in an end state, but I feel like enough is done to submit for PR for feedback.