### PR TITLE
DOC: Harmonize skfuzzy branding.

### DIFF
--- a/TASKS.txt
+++ b/TASKS.txt
@@ -3,7 +3,7 @@
 
 .. _howto_contribute:
 
-How to contribute to ``skimage``
+How to contribute to ``skfuzzy``
 ======================================
 
 .. toctree::
@@ -13,8 +13,8 @@ How to contribute to ``skimage``
 
 
 Developing Open Source is great fun!  Join us on the `scikit-fuzzy mailing
-list <http://groups.google.com/group/scikit-fuzzy>`_ and tell us which of the
-following challenges you'd like to solve.
+list <http://groups.google.com/group/scikit-fuzzy>`_ and tell us which
+challenges you'd like to solve.
 
 * Guidance is available for those new to scientific programming in Python.
 * If you're looking for something to implement, you can browse the `open issues

--- a/docs/source/_static/docversions.js
+++ b/docs/source/_static/docversions.js
@@ -10,9 +10,9 @@ function insert_version_links() {
             }
         }
         document.write(open_list);
-        document.write('<a href="URL">skimage VERSION</a> </li>\n'
+        document.write('<a href="URL">skfuzzy VERSION</a> </li>\n'
                         .replace('VERSION', versions[i])
-                        .replace('URL', 'http://scikit-image.org/docs/' + versions[i]));
+                        .replace('URL', 'http://http://pythonhosted.org/scikit-fuzzy/' + versions[i]));
     }
 }
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -159,7 +159,7 @@ html_theme_path = ['themes']
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-html_title = 'skimage v{0} docs'.format(version)
+html_title = 'skfuzzy v{0} docs'.format(version)
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #html_short_title = None

--- a/docs/source/index.txt
+++ b/docs/source/index.txt
@@ -36,7 +36,7 @@ Sections
 
    * - `Installation Steps <install.html>`_
 
-       How to install skimage.
+       How to install skfuzzy.
 
      - `User Guide <user_guide.html>`_
 

--- a/docs/tools/apigen.py
+++ b/docs/tools/apigen.py
@@ -13,15 +13,16 @@ Previously functions and classes were found by parsing the text of .py files.
 Extension modules should be discovered and included as well.
 
 This is a modified version of a script originally shipped with the PyMVPA
-project, then adapted for use first in NIPY and then in skimage. PyMVPA
-is an MIT-licensed project.
+project, then adapted for use first in NIPY, then in skimage, and now in
+skfuzzy. PyMVPA is an MIT-licensed project and skimage is licensed under the
+3-clause BSD.
 """
 
 # Stdlib imports
 import os
 import re
 
-from types import BuiltinFunctionType, FunctionType
+from types import FunctionType
 
 # suppress print statements (warnings for empty files)
 DEBUG = True
@@ -156,7 +157,7 @@ class ApiDocWriter(object):
         path = path.replace('.', os.path.sep)
         path = os.path.join(self.root_path, path)
         # XXX maybe check for extensions as well?
-        if os.path.exists(path + '.py'): # file
+        if os.path.exists(path + '.py'):  # file
             path += '.py'
         elif os.path.exists(os.path.join(path, '__init__.py')):
             path = os.path.join(path, '__init__.py')
@@ -178,7 +179,7 @@ class ApiDocWriter(object):
         if filename is None:
             print(filename, 'erk')
             # nothing that we could handle here.
-            return ([],[])
+            return ([], [])
         f = open(filename, 'rt')
         functions, classes = self._parse_lines(f)
         f.close()
@@ -265,7 +266,7 @@ class ApiDocWriter(object):
 
         # Make a shorter version of the uri that omits the package name for
         # titles
-        uri_short = re.sub(r'^%s\.' % self.package_name,'',uri)
+        uri_short = re.sub(r'^%s\.' % self.package_name, '', uri)
 
         ad = '.. AUTO-GENERATED FILE -- DO NOT EDIT!\n\n'
 
@@ -377,10 +378,10 @@ class ApiDocWriter(object):
             # Check directory names for packages
             root_uri = self._path2uri(os.path.join(self.root_path,
                                                    dirpath))
-            for dirname in dirnames[:]: # copy list - we modify inplace
+            for dirname in dirnames[:]:  # copy list - we modify inplace
                 package_uri = '.'.join((root_uri, dirname))
                 if (self._uri2path(package_uri) and
-                    self._survives_exclude(package_uri, 'package')):
+                        self._survives_exclude(package_uri, 'package')):
                     modules.append(package_uri)
                 else:
                     dirnames.remove(dirname)
@@ -453,7 +454,7 @@ class ApiDocWriter(object):
         else:
             relpath = outdir
         print("outdir: ", relpath)
-        idx = open(path,'wt')
+        idx = open(path, 'wt')
         w = idx.write
         w('.. AUTO-GENERATED FILE -- DO NOT EDIT!\n\n')
 
@@ -462,5 +463,5 @@ class ApiDocWriter(object):
         w("=" * len(title) + "\n\n")
         w('.. toctree::\n\n')
         for f in self.written_modules:
-            w('   %s\n' % os.path.join(relpath,f))
+            w('   %s\n' % os.path.join(relpath, f))
         idx.close()

--- a/skfuzzy/image/shape.py
+++ b/skfuzzy/image/shape.py
@@ -33,7 +33,7 @@ def view_as_blocks(arr_in, block_shape):
     Examples
     --------
     >>> import numpy as np
-    >>> from skimage.util.shape import view_as_blocks
+    >>> from skfuzzy import view_as_blocks
     >>> A = np.arange(4*4).reshape(4,4)
     >>> A
     array([[ 0,  1,  2,  3],
@@ -147,7 +147,7 @@ def view_as_windows(arr_in, window_shape):
     Examples
     --------
     >>> import numpy as np
-    >>> from skimage.util.shape import view_as_windows
+    >>> from skfuzzy import view_as_windows
     >>> A = np.arange(4*4).reshape(4,4)
     >>> A
     array([[ 0,  1,  2,  3],


### PR DESCRIPTION
This PR fixes a few places, mostly in the docs, where mentions of `skimage` remained after borrowing the doc build from scikit-image. They are now converted to `skfuzzy`; I believe none remain out of place.

Also a few PEP8 fixes.