### PR TITLE
Fix Python 3 bug from nilayrox18

### DIFF
--- a/skfuzzy/control/controlsystem.py
+++ b/skfuzzy/control/controlsystem.py
@@ -144,7 +144,7 @@ class ControlSystemSimulation(object):
         for antecedent in self.ctrl.antecedents:
             if antecedent.input[self] is None:
                 raise ValueError("All antecedents must have input values!")
-            if antecedent.terms.values()[0].membership_value[self] is not None:
+            if list(antecedent.terms.values())[0].membership_value[self] is not None:
                 raise RuntimeError("Antecedent already has calculated "
                 "membership.  Are you trying to computer a simulation multiple "
                 "times?  Create multiple ControlSystemSimulation objects "
@@ -345,7 +345,7 @@ class RuleOrderGenerator(object):
         # have fuzzy values
         self.calced_graph = nx.DiGraph()
         for a in self.ctrl.antecedents:
-            self.calced_graph.add_star([a, ] + a.terms.values())
+            self.calced_graph.add_star([a, ] + list(a.terms.values()))
 
         self.all_graph = self.ctrl.graph
 


### PR DESCRIPTION
Bug reported by @nilayrox18:

Requires python 3 to reproduce:
```python
import numpy as np
import skfuzzy as fuzz

quality = fuzz.Antecedent(np.arange(0,11,1),'quality')
service = fuzz.Antecedent(np.arange(0,11,1),'service')

tip = fuzz.Consequent(np.arange(0,26,1),'tip')

quality.automf(3)
service.automf(3)
tip.automf(3)

quality.view()
service.view()
tip.view()

rule1 = fuzz.Rule(quality['poor'] | service['poor'],tip['poor'])
rule2 = fuzz.Rule(quality['good'] | service['good'],tip['good'])

tip_cnt = fuzz.ControlSystem([rule1, rule2])

tipp = fuzz.ControlSystemSimulation(tip_cnt)

tipp.input['quality'] = 5.
tipp.input['service'] = 2.

tipp.compute()

print(tipp.output)
```

Error message is:

Traceback (most recent call last):
File "C:\Users\DarkEvill\Desktop\ex3456.py", line 29, in 
tipp.compute()
File "C:\Python34\lib\site-packages\scikit_fuzzy-0.2dev-py3.4.egg\skfuzzy\control\controlsystem.py", line 147, in compute
if antecedent.terms.values()[0].membership_value[self] is not None:
TypeError: 'ValuesView' object does not support indexing