### PR TITLE
DOCFIX: Resolve Sphinx refernce warnings in doc build.

### DIFF
--- a/skfuzzy/cluster/_cmeans.py
+++ b/skfuzzy/cluster/_cmeans.py
@@ -1,6 +1,5 @@
 """
 cmeans.py : Fuzzy C-means clustering algorithm.
-
 """
 import numpy as np
 from scipy.spatial.distance import cdist
@@ -8,12 +7,12 @@ from scipy.spatial.distance import cdist
 
 def _cmeans0(data, u_old, c, m):
     """
-    Single step in generic fuzzy c-means clustering algorithm. Modified from
-    Ross, Fuzzy Logic w/Engineering Applications (2010) p.352-353, equations
-    10.28 - 10.35.
+    Single step in generic fuzzy c-means clustering algorithm.
+
+    Modified from Ross, Fuzzy Logic w/Engineering Applications (2010),
+    pages 352-353, equations 10.28 - 10.35.
 
     Parameters inherited from cmeans()
-
     """
     # Normalizing, then eliminating any potential zero values.
     u_old /= np.ones((c, 1)).dot(np.atleast_2d(u_old.sum(axis=0)))
@@ -39,8 +38,7 @@ def _cmeans0(data, u_old, c, m):
 
 def _distance(data, centers):
     """
-    Calcuate Euclidean distance from each point to each cluster center,
-    returning results in matrix form.
+    Euclidean distance from each point to each cluster center.
 
     Parameters
     ----------
@@ -65,7 +63,7 @@ def _distance(data, centers):
 def _fp_coeff(u):
     """
     Fuzzy partition coefficient `fpc` relative to fuzzy c-partitioned
-    matrix u. Measures 'fuzziness' in partitioned clustering.
+    matrix `u`. Measures 'fuzziness' in partitioned clustering.
 
     Parameters
     ----------
@@ -86,7 +84,7 @@ def _fp_coeff(u):
 
 def cmeans(data, c, m, error, maxiter, init=None, seed=None):
     """
-    Fuzzy c-means clustering algorithm [1]_.
+    Fuzzy c-means clustering algorithm [1].
 
     Parameters
     ----------
@@ -176,7 +174,7 @@ def cmeans(data, c, m, error, maxiter, init=None, seed=None):
 def cmeans_predict(test_data, cntr_trained, m, error, maxiter, init=None,
                    seed=None):
     """
-    Prediction of new data in given a trained fuzzy c-means framework [1]_.
+    Prediction of new data in given a trained fuzzy c-means framework [1].
 
     Parameters
     ----------

--- a/skfuzzy/filters/fire.py
+++ b/skfuzzy/filters/fire.py
@@ -10,7 +10,7 @@ from ..membership import trimf
 
 def fire1d(x, l1=0, l2=1):
     """
-    1-D filtering using Fuzzy Inference Ruled by Else-action (FIRE) [1]_
+    1-D filtering using Fuzzy Inference Ruled by Else-action (FIRE) [1].
 
     FIRE filtering is nonlinear, and is specifically designed to remove
     impulse (salt and pepper) noise.
@@ -91,7 +91,7 @@ def fire1d(x, l1=0, l2=1):
 
 def fire2d(im, l1=0, l2=255, fuzzyresolution=1):
     """
-    2-D filtering using Fuzzy Inference Ruled by Else-action (FIRE) [1]_
+    2-D filtering using Fuzzy Inference Ruled by Else-action (FIRE) [1].
 
     FIRE filtering is nonlinear, and is specifically designed to remove
     impulse (salt and pepper) noise.

--- a/skfuzzy/intervals/intervalops.py
+++ b/skfuzzy/intervals/intervalops.py
@@ -1,6 +1,5 @@
 """
 intervalops.py : Functions for proper mathematical treatment of intervals.
-
 """
 from __future__ import division, print_function
 import numpy as np
@@ -9,7 +8,7 @@ from ..defuzzify import lambda_cut_series
 
 def addval(interval1, interval2):
     """
-    Adds intervals interval1 and interval2.
+    Add intervals interval1 and interval2.
 
     Parameters
     ----------
@@ -40,7 +39,7 @@ def addval(interval1, interval2):
 
 def divval(interval1, interval2):
     """
-    Divides interval2 into interval1, by inverting interval2 and multiplying.
+    Divide ``interval2`` into ``interval1``, by inversion and multiplication.
 
     Parameters
     ----------
@@ -68,7 +67,7 @@ def divval(interval1, interval2):
 
 def dsw_add(x, mfx, y, mfy, n):
     """
-    Add two fuzzy variables together using the restricted DSW method [1]_.
+    Add two fuzzy variables together using the restricted DSW method [1].
 
     Parameters
     ----------
@@ -126,7 +125,7 @@ def dsw_add(x, mfx, y, mfy, n):
 
 def dsw_div(x, mfx, y, mfy, n):
     """
-    Divide one fuzzy variable by another using the restricted DSW method [1]_.
+    Divide one fuzzy variable by another using the restricted DSW method [1].
 
     Parameters
     ----------
@@ -185,7 +184,7 @@ def dsw_div(x, mfx, y, mfy, n):
 
 def dsw_mult(x, mfx, y, mfy, n):
     """
-    Multiply two fuzzy variables using the restricted DSW method [1]_.
+    Multiply two fuzzy variables using the restricted DSW method [1].
 
     Parameters
     ----------
@@ -244,7 +243,7 @@ def dsw_mult(x, mfx, y, mfy, n):
 
 def dsw_sub(x, mfx, y, mfy, n):
     """
-    Subtract a fuzzy variable from another by the restricted DSW method [1]_.
+    Subtract a fuzzy variable from another by the restricted DSW method [1].
 
     Parameters
     ----------
@@ -304,7 +303,7 @@ def dsw_sub(x, mfx, y, mfy, n):
 
 def multval(interval1, interval2):
     """
-    Multiplies intervals interval1 and interval2.
+    Multiply intervals interval1 and interval2.
 
     Parameters
     ----------
@@ -337,7 +336,7 @@ def multval(interval1, interval2):
 
 def scaleval(q, interval):
     """
-    Multiplies scalar q with interval interval.
+    Multiply scalar q with interval ``interval``.
 
     Parameters
     ----------
@@ -365,7 +364,7 @@ def scaleval(q, interval):
 
 def subval(interval1, interval2):
     """
-    Subtracts interval interval2 from interval interval1.
+    Subtract interval interval2 from interval interval1.
 
     Parameters
     ----------


### PR DESCRIPTION
A number of docstrings had an underscore after a bracketed, numbered reference on the first line. Sphinx doesn't like this in the first line; everywhere else it's correct, but in the first line you get these warnings.

Minor tweaks to make things a little more imperative.

The doc build should now be completely clean without any warnings.