### PR TITLE
DOCFIX: Fix broken relative links between pages.

### DIFF
--- a/docs/examples/plot_tipping_problem_newapi.py
+++ b/docs/examples/plot_tipping_problem_newapi.py
@@ -9,7 +9,7 @@ expert rules.
 
 If you're new to the world of fuzzy control systems, you might want
 to check out the `Fuzzy Control Primer
-<../../userguide/fuzzy_control_primer.html>`_
+<../userguide/fuzzy_control_primer.html>`_
 before reading through this worked example.
 
 The Tipping Problem

--- a/docs/source/userguide/fuzzy_control_primer.txt
+++ b/docs/source/userguide/fuzzy_control_primer.txt
@@ -69,4 +69,4 @@ Example
 -------
 To see a worked example of the tipping problem using the :mod:`scikit-fuzzy`
 library visit the `Fuzzy Control Systems example
-<../../auto_examples/plot_tipping_problem.html>`_.
+<../auto_examples/plot_tipping_problem.html>`_.

--- a/docs/source/userguide/getting_started.txt
+++ b/docs/source/userguide/getting_started.txt
@@ -22,7 +22,7 @@ Finding your way around
 -----------------------
 
 A list of submodules and functions is found on the `API reference
-<../../api/api.html>`_ webpage.
+<../api/api.html>`_ webpage.
 
 Within :mod:`scikit-fuzzy`, universe variables and fuzzy membership functions are
 represented by :mod:`numpy` arrays. Generation of membership functions is


### PR DESCRIPTION
Fixes three broken links. Up one level is all that's required to link between sections of the HTML docs.