### PR TITLE
FIX: Pip installation succeeds regardless of permissions

### DIFF
--- a/DEPENDS.txt
+++ b/DEPENDS.txt
@@ -1,7 +1,8 @@
 #################################
 # Requirements for scikit-fuzzy #
 #################################
-# The current requirements to install and run the package are stored in
-# ./setup.py and are grabbed from there at install time via Pip.
+# The current requirements to install and run the package
 
--e .
+numpy>=1.6.0
+scipy>=0.9.0
+networkx>=1.9.0

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,15 @@
+include setup.cfg
+include setup*.py
+include MANIFEST.in
+include *.txt
+include Makefile
+recursive-include skfuzzy *.pyx *.pxd *.pxi *.py *.c *.h *.ini *.md5 *.npy *.txt
+recursive-include skfuzzy/data *
+
+include docs/Makefile
+recursive-include docs/source *.txt
+recursive-include docs/tools *.txt
+recursive-include docs/source/_templates *.html
+recursive-include docs *.py
+prune docs/build
+prune docs/gh-pages

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -95,10 +95,10 @@ version = '0.1'
 #import skfuzzy.version
 #release = skfuzzy.version
 
-setup_lines = open('../../setup.py').readlines()
+setup_lines = open('../../skimage/__init__.py').readlines()
 version = 'vUndefined'
 for l in setup_lines:
-    if l.startswith('VERSION'):
+    if l.startswith('__version__'):
         version = l.split("'")[1]
         break
 

--- a/docs/tools/build_modref_templates.py
+++ b/docs/tools/build_modref_templates.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-"""Script to auto-generate our API docs.
-"""
+"""Script to auto-generate our API docs."""
 # stdlib imports
 import sys
 
@@ -36,10 +35,10 @@ if __name__ == '__main__':
     # are not (re)generated. This avoids automatic generation of documentation
     # for older or newer versions if such versions are installed on the system.
 
-    setup_lines = open('../setup.py').readlines()
+    source_lines = open('../skimage/__init__.py').readlines()
     version = 'vUndefined'
-    for l in setup_lines:
-        if l.startswith('VERSION'):
+    for l in source_lines:
+        if l.startswith('__version__'):
             source_version = LooseVersion(l.split("'")[1])
             break
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ import os
 import sys
 
 import setuptools
-from distutils.command.build_py import setup
+from distutils.command.build_py import build_py
 
 if sys.version_info[0] < 3:
     import __builtin__ as builtins
@@ -36,14 +36,18 @@ else:
 builtins.__SKIMAGE_SETUP__ = True
 
 
-with open('skimage/__init__.py') as fid:
+with open('skfuzzy/__init__.py') as fid:
     for line in fid:
         if line.startswith('__version__'):
             VERSION = line.strip().split()[-1][1:-1]
             break
 
-with open('requirements.txt') as fid:
-    INSTALL_REQUIRES = [l.strip() for l in fid.readlines() if l]
+with open('DEPENDS.txt') as fid:
+    INSTALL_REQUIRES = []
+    for line in fid.readlines():
+        if line == '' or line[0] == '#' or line[0].isspace():
+            continue
+        INSTALL_REQUIRES.append(line.strip())
 
 # requirements for those browsing PyPI
 REQUIRES = [r.replace('>=', ' (>= ') + ')' for r in INSTALL_REQUIRES]
@@ -75,7 +79,7 @@ if __name__ == "__main__":
         from numpy.distutils.core import setup
         extra = {'configuration': configuration}
         # Do not try and upgrade larger dependencies
-        for lib in ['numpy', 'matplotlib']:
+        for lib in ['numpy', 'scipy', 'matplotlib']:
             try:
                 __import__(lib)
                 INSTALL_REQUIRES = [i for i in INSTALL_REQUIRES
@@ -113,13 +117,13 @@ if __name__ == "__main__":
         version=VERSION,
         package_data={
             # Include saved test image
-            '': ['*.npy', '*.md', ],
+            '': ['*.npy', '*.md', '*.txt'],
         },
 
         classifiers=[
             'Development Status :: 4 - Beta',
             'Environment :: Console',
-            'Intended Audience :: Developers, scientists',
+            'Intended Audience :: Developers',
             'Intended Audience :: Science/Research',
             'License :: OSI Approved :: BSD License',
             'Programming Language :: Python',
@@ -130,11 +134,12 @@ if __name__ == "__main__":
             'Operating System :: Unix',
             'Operating System :: MacOS'],
 
-        configuration=configuration,
-        setup_requires=SETUP_REQUIRES,
         install_requires=INSTALL_REQUIRES,
         requires=REQUIRES,
         packages=setuptools.find_packages(exclude=['docs']),
         include_package_data=True,
-        zip_safe=False
+        zip_safe=False,
+
+        cmdclass={'build_py': build_py},
+        **extra
     )

--- a/setup.py
+++ b/setup.py
@@ -15,73 +15,40 @@ MAINTAINER_EMAIL    = 'joshua.dale.warner@gmail.com'
 LICENSE             = 'Modified BSD'
 URL                 = 'https://pypi.python.org/pypi/scikit-fuzzy'
 DOWNLOAD_URL        = 'https://github.com/scikit-fuzzy/scikit-fuzzy'
-VERSION             = '0.2dev'
-PYTHON_VERSION      = (2, 5)
-DEPENDENCIES        = {'numpy': (1, 6),
-                       'scipy': (0, 9),
-                       'networkx': (1, 9)}
-
 
 import os
 import sys
-import re
+
 import setuptools
-from numpy.distutils.core import setup
-try:
-    from distutils.command.build_py import build_py_2to3 as build_py
-except ImportError:
-    from distutils.command.build_py import build_py
+from distutils.command.build_py import setup
+
+if sys.version_info[0] < 3:
+    import __builtin__ as builtins
+else:
+    import builtins
+
+# This is a bit (!) hackish: we are setting a global variable so that the main
+# skimage __init__ can detect if it is being loaded by the setup routine, to
+# avoid attempting to load components that aren't built yet:
+# the numpy distutils extensions that are used by scikit-image to recursively
+# build the compiled extensions in sub-packages is based on the Python import
+# machinery.
+builtins.__SKIMAGE_SETUP__ = True
 
 
-def check_requirements():
-    if sys.version_info < PYTHON_VERSION:
-        raise SystemExit('Python version %d.%d required; found %d.%d.'
-                         % (PYTHON_VERSION[0], PYTHON_VERSION[1],
-                            sys.version_info[0], sys.version_info[1]))
+with open('skimage/__init__.py') as fid:
+    for line in fid:
+        if line.startswith('__version__'):
+            VERSION = line.strip().split()[-1][1:-1]
+            break
 
-    for package_name, min_version in DEPENDENCIES.items():
-        dep_err = False
-        try:
-            package = __import__(package_name)
-        except ImportError:
-            dep_err = True
-        else:
-            package_version = get_package_version(package)
-            if min_version > package_version:
-                dep_err = True
+with open('requirements.txt') as fid:
+    INSTALL_REQUIRES = [l.strip() for l in fid.readlines() if l]
 
-        if dep_err:
-            raise ImportError('`%s` version %d.%d or later required.'
-                              % ((package_name, ) + min_version))
-
-
-def get_package_version(package):
-    version = []
-    for version_attr in ('version', 'VERSION', '__version__'):
-        if hasattr(package, version_attr) \
-                and isinstance(getattr(package, version_attr), str):
-            version_info = getattr(package, version_attr, '')
-            for part in re.split('\D+', version_info):
-                try:
-                    version.append(int(part))
-                except ValueError:
-                    pass
-
-    return tuple(version)
-
-
-def write_version_py(filename='skfuzzy/version.py'):
-    template = """# THIS FILE IS GENERATED FROM THE SKFUZZY SETUP.PY
-version='%s'
-"""
-
-    vfile = open(os.path.join(os.path.dirname(__file__),
-                              filename), 'w')
-
-    try:
-        vfile.write(template % VERSION)
-    finally:
-        vfile.close()
+# requirements for those browsing PyPI
+REQUIRES = [r.replace('>=', ' (>= ') + ')' for r in INSTALL_REQUIRES]
+REQUIRES = [r.replace('==', ' (== ') for r in REQUIRES]
+REQUIRES = [r.replace('[array]', '') for r in REQUIRES]
 
 
 def configuration(parent_package='', top_path=None):
@@ -91,20 +58,48 @@ def configuration(parent_package='', top_path=None):
     from numpy.distutils.misc_util import Configuration
     config = Configuration(None, parent_package, top_path)
 
-    config.set_options(ignore_setup_xxx_py=True,
-                       assume_default_configuration=True,
-                       delegate_options_to_subpackages=True,
-                       quiet=True)
+    config.set_options(
+        ignore_setup_xxx_py=True,
+        assume_default_configuration=True,
+        delegate_options_to_subpackages=True,
+        quiet=True)
 
     config.add_subpackage('skfuzzy')
-    # config.add_data_dir('skfuzzy/data')
+    config.add_data_dir('skfuzzy/data')
 
     return config
 
 
-if __name__ == '__main__':
-    check_requirements()
-    write_version_py()
+if __name__ == "__main__":
+    try:
+        from numpy.distutils.core import setup
+        extra = {'configuration': configuration}
+        # Do not try and upgrade larger dependencies
+        for lib in ['numpy', 'matplotlib']:
+            try:
+                __import__(lib)
+                INSTALL_REQUIRES = [i for i in INSTALL_REQUIRES
+                                    if lib not in i]
+            except ImportError:
+                pass
+    except ImportError:
+        if len(sys.argv) >= 2 and ('--help' in sys.argv[1:] or
+                                   sys.argv[1] in ('--help-commands',
+                                                   '--version',
+                                                   'clean')):
+            # For these actions, NumPy is not required.
+            #
+            # They are required to succeed without Numpy for example when
+            # pip is used to install scikit-image when Numpy is not yet
+            # present in the system.
+            from setuptools import setup
+            extra = {}
+        else:
+            print('To install scikit-fuzzy from source, you will need numpy.\n' +
+                  'Install numpy with pip:\n' +
+                  'pip install numpy\n'
+                  'Or use your operating system package manager.')
+            sys.exit(1)
 
     setup(
         name=DISTNAME,
@@ -136,7 +131,10 @@ if __name__ == '__main__':
             'Operating System :: MacOS'],
 
         configuration=configuration,
-
-        packages=setuptools.find_packages(),
+        setup_requires=SETUP_REQUIRES,
+        install_requires=INSTALL_REQUIRES,
+        requires=REQUIRES,
+        packages=setuptools.find_packages(exclude=['docs']),
+        include_package_data=True,
         zip_safe=False
     )

--- a/skfuzzy/__init__.py
+++ b/skfuzzy/__init__.py
@@ -14,12 +14,7 @@ Recommended Use
 """
 __all__ = []
 
-try:
-    from .version import version as __version__
-except ImportError:
-    __version__ = "unbuilt-dev"
-else:
-    del version
+__version__ = '0.1.4'
 
 ######################
 # Subpackage imports #
@@ -64,3 +59,87 @@ __all__.extend(_image.__all__)
 import skfuzzy.control as _control
 from skfuzzy.control import *
 __all__.extend(_control.__all__)
+
+# Enable testing of the package
+try:
+    imp.find_module('nose')
+except ImportError:
+    def _test(doctest=False, verbose=False):
+        """This would run all unit tests, but nose couldn't be
+        imported so the test suite can not run.
+        """
+        raise ImportError("Could not load nose. Unit tests not available.")
+
+else:
+    def _test(doctest=False, verbose=False):
+        """Run all unit tests."""
+        import nose
+        args = ['', pkg_dir, '--exe', '--ignore-files=^_test']
+        if verbose:
+            args.extend(['-v', '-s'])
+        if doctest:
+            args.extend(['--with-doctest', '--ignore-files=^\.',
+                         '--ignore-files=^setup\.py$$', '--ignore-files=test'])
+            # Make sure warnings do not break the doc tests
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                success = nose.run('skimage', argv=args)
+        else:
+            success = nose.run('skimage', argv=args)
+        # Return sys.exit code
+        if success:
+            return 0
+        else:
+            return 1
+
+
+# do not use `test` as function name as this leads to a recursion problem with
+# the nose test suite
+test = _test
+test_verbose = functools.partial(test, verbose=True)
+test_verbose.__doc__ = test.__doc__
+doctest = functools.partial(test, doctest=True)
+doctest.__doc__ = doctest.__doc__
+doctest_verbose = functools.partial(test, doctest=True, verbose=True)
+doctest_verbose.__doc__ = doctest.__doc__
+
+
+# Logic for checking for improper install and importing while in the source
+# tree when package has not been installed inplace.
+# Code adapted from scikit-learn's __check_build module.
+_INPLACE_MSG = """
+It appears that you are importing a local scikit-fuzzy source tree. For
+this, you need to have an inplace install. Maybe you are in the source
+directory and you need to try from another location."""
+
+_STANDARD_MSG = """
+Your install of scikit-fuzzy appears to be broken.
+Try re-installing the package."""
+
+
+def _raise_build_error(e):
+    # Raise a comprehensible error
+    local_dir = osp.split(__file__)[0]
+    msg = _STANDARD_MSG
+    if local_dir == "skfuzzy":
+        # Picking up the local install: this will work only if the
+        # install is an 'inplace build'
+        msg = _INPLACE_MSG
+    raise ImportError("""%s
+It seems that scikit-fuzzy has not been built correctly.
+%s""" % (e, msg))
+
+try:
+    # This variable is injected in the __builtins__ by the build
+    # process. It used to enable importing subpackages of skimage when
+    # the binaries are not built
+    __SKFUZZY_SETUP__
+except NameError:
+    __SKFUZZY_SETUP__ = False
+
+if __SKFUZZY_SETUP__:
+    sys.stderr.write('Partial import of skfuzzy during the build process.\n')
+    # We are not importing the rest of the scikit during the build
+    # process, as it may not be compiled yet
+
+del warnings, functools, osp, imp, sys

--- a/skfuzzy/__init__.py
+++ b/skfuzzy/__init__.py
@@ -14,7 +14,7 @@ Recommended Use
 """
 __all__ = []
 
-__version__ = '0.1.4'
+__version__ = '0.2dev'
 
 ######################
 # Subpackage imports #
@@ -61,6 +61,15 @@ from skfuzzy.control import *
 __all__.extend(_control.__all__)
 
 # Enable testing of the package
+import os.path as osp
+import imp
+import functools
+import warnings
+import sys
+
+pkg_dir = osp.abspath(osp.dirname(__file__))
+data_dir = osp.join(pkg_dir, 'data')
+
 try:
     imp.find_module('nose')
 except ImportError:


### PR DESCRIPTION
Pip installation should no longer ever result in a broken installation due to permissions issues around `version.py`.

Thanks to troubleshooting this issue on Windows and a few false starts, the PyPI version bumped from 0.1.3 to 0.1.9 tonight.

Closes #87.