### PR TITLE
New API cleanup

### DIFF
--- a/skfuzzy/control/controlsystem.py
+++ b/skfuzzy/control/controlsystem.py
@@ -157,11 +157,11 @@ class ControlSystemSimulation(object):
         for antecedent in self.ctrl.antecedents:
             if antecedent.input[self] is None:
                 raise ValueError("All antecedents must have input values!")
-            # if list(antecedent.terms.values())[0].membership_value[self] is not None:
-            #     raise RuntimeError("Antecedent already has calculated "
-            #     "membership.  Are you trying to computer a simulation multiple "
-            #     "times?  Create multiple ControlSystemSimulation objects "
-            #     "instead.")
+            if list(antecedent.terms.values())[0].membership_value[self] is not None:
+                raise RuntimeError("Antecedent already has calculated "
+                "membership.  Are you trying to computer a simulation multiple "
+                "times?  Create multiple ControlSystemSimulation objects "
+                "instead.")
             CrispValueCalculator(antecedent, self).fuzz(antecedent.input[self])
 
         # Calculate rules, taking inputs and accumulating outputs
@@ -297,7 +297,9 @@ class CrispValueCalculator(object):
         return defuzz(self.var.universe, output_mf, self.var.defuzzify_method)
 
     def fuzz(self, value):
-        """Propagate crisp value down to adjectives by calculating membership"""
+        """
+        Propagate crisp value down to adjectives by calculating membership.
+        """
         if len(self.var.terms) == 0:
             raise ValueError("Set Term membership function(s) first")
 
@@ -319,7 +321,7 @@ class CrispValueCalculator(object):
         for label, term in self.var.terms.items():
             cut = term.membership_value[self.sim]
             if cut is None:
-                continue # No membership defined for this adjective
+                continue  # No membership defined for this adjective
             term_mfs[label] = np.minimum(cut, term.mf)
             np.maximum(output_mf, term_mfs[label], output_mf)
 

--- a/skfuzzy/control/rule.py
+++ b/skfuzzy/control/rule.py
@@ -89,7 +89,8 @@ class Rule(object):
             may be combined using operators `|` (OR), `&` (AND), `~` (NOT), and
             parentheticals to group terms.
         label : string, optional
-        Label to reference the meaning of this rule. Optional, but recommended.
+            Label to reference the meaning of this rule. Optional, but
+            recommended.
         """
         self.label = label
         self.aggregation_method = FuzzyAggregationMethod()

--- a/skfuzzy/control/tests/test_fuzzyvariables.py
+++ b/skfuzzy/control/tests/test_fuzzyvariables.py
@@ -48,7 +48,6 @@ def test_instantiate_antecedent():
     # Assure expected behavior
     tst.assert_equal(universe, ant.universe)
     assert ant.label == label
-    assert ant.input is None
     assert ant._id == id(ant)
     assert_empty_ordereddict(ant.terms)
     assert ant.__name__ == 'Antecedent'
@@ -275,36 +274,6 @@ def test_add_mf():
 
 
 @nose.with_setup(setup)
-def test_set_patch():
-    global con
-
-    # Consequent only test, the analogue of Antecedent's input
-    con.automf(3)
-
-    # Setting a patch
-    con.set_patch('average', 0.4)
-
-    # Overriding it with a higher patch
-    con.set_patch('average', 0.55)
-
-    # Setting the other patches
-    con.set_patch('good', 0.3)
-    con.set_patch('poor', 0.88)
-
-    tst.assert_allclose(con.output, 3.6644951140065136)
-
-
-@nose.with_setup(setup)
-def test_set_input():
-    global ant
-    ant.automf(3)
-    ant.input = 2.3
-
-    assert ant.input == 2.3, "Value is %s" % ant.input
-    assert ant.crisp_value == 2.3, "Value is %s" % ant.crisp_value
-
-
-@nose.with_setup(setup)
 def test_add_bad_mf():
     global ant
     global con
@@ -314,16 +283,6 @@ def test_add_bad_mf():
 
     tst.assert_raises(ValueError, con.__setitem__, 'new_mf', np.ones(30))
     tst.assert_raises(ValueError, con.__setitem__, 'low', np.arange(10))
-
-
-@nose.with_setup(setup)
-def test_cannot_compute():
-    global ant
-    global con
-    with tst.assert_raises(ValueError):
-        ant.input
-    with tst.assert_raises(ValueError):
-        con.output
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Functionally the most important change is naming `WeightedConsequent` -> `WeightedTerm`, and `FuzzyVariableTerm` became `Term`. Given how these worked and what they required, this reflects their actual function.

Lots more docstrings and style improvements. This addresses in large part #77, but there is still room for some improvement. Improved `view` for Terms so the legend reflects the bold, active membership function.

Also, the tests should now pass! 

What I consider blocking before 0.2 release:

- [ ] Ability to repeatedly `.compute` using a single simulation object
- [ ] Check for overly sparse system, warn the user, and catch these cases so more informative error messages are raised

What do you think, @jsexauer?