### PR TITLE
Repeated simulations

### DIFF
--- a/skfuzzy/control/controlsystem.py
+++ b/skfuzzy/control/controlsystem.py
@@ -327,7 +327,7 @@ class ControlSystemSimulation(object):
                 term.membership_value[self] = accu(value,
                                                    term.membership_value[self])
 
-            term.cuts[self][rule] = value
+            term.cuts[self][rule.label] = value
 
     def print_state(self):
         if self.ctrl.consequents.next().output[self] is None:

--- a/skfuzzy/control/controlsystem.py
+++ b/skfuzzy/control/controlsystem.py
@@ -189,12 +189,11 @@ class ControlSystemSimulation(object):
     cache : bool, optional
         Controls if results should be stored for reference in fuzzy variable
         objects, allowing fast lookup for repeated runs of `.compute()`.
-        If your system is small or you are prototyping, leave this `True`.
-        If your system is large and you have memory concerns, for example with
-        embedded devices, set this to `False`.
+        If your system is small and accepts only integer inputs, consider
+        setting this `True`. For most other uses, leave this off (`False`).
     """
 
-    def __init__(self, control_system, clip_to_bounds=True, cache=True):
+    def __init__(self, control_system, clip_to_bounds=True, cache=False):
         assert isinstance(control_system, ControlSystem)
         self.ctrl = control_system
 

--- a/skfuzzy/control/fuzzyvariable.py
+++ b/skfuzzy/control/fuzzyvariable.py
@@ -43,10 +43,10 @@ class TermPrimitive(object):
 
 class Term(TermPrimitive):
     """
-    An term and associated member function for a fuzzy varaible.
+    A Term is a universe and associated specific membership function.
+
     For example, if one were creating a FuzzyVariable with a simple three-point
-    liker scale, three `Term` would be created: poor, average,
-    and good.
+    liker scale, three `Term` would be created: poor, average, and good.
     """
 
     # State variables

--- a/skfuzzy/control/fuzzyvariable.py
+++ b/skfuzzy/control/fuzzyvariable.py
@@ -151,6 +151,7 @@ class TermAggregate(TermPrimitive):
     @property
     def agg_method(self):
         return self._agg_method
+
     @agg_method.setter
     def agg_method(self, value):
         if not isinstance(value, FuzzyAggregationMethod):
@@ -161,7 +162,6 @@ class TermAggregate(TermPrimitive):
         for term in (self.term1, self.term2):
             if isinstance(term, TermAggregate):
                 term.agg_method = value
-
 
 
 class FuzzyVariable(object):
@@ -184,6 +184,7 @@ class FuzzyVariable(object):
     This class is designed as the base class underlying the Antecedent and
     Consequent classes, not for individual use.
     """
+
     def __init__(self, universe, label, defuzzify_method='centroid'):
         """
         Initialization of fuzzy variable
@@ -211,7 +212,7 @@ class FuzzyVariable(object):
 
     def __getitem__(self, key):
         """
-        Calling variable['label'] will return the 'label' term
+        Calling `variable['label']` will return the 'label' term
         """
         if key in self.terms.keys():
             return self.terms[key]

--- a/skfuzzy/control/rule.py
+++ b/skfuzzy/control/rule.py
@@ -64,6 +64,8 @@ class Rule(object):
         parentheticals to group terms.
     label : string, optional
         Label to reference the meaning of this rule. Optional, but recommended.
+        If provided, the label must be unique among rules in any particular
+        `ControlSystem`.
 
     Notes
     -----

--- a/skfuzzy/control/rule.py
+++ b/skfuzzy/control/rule.py
@@ -92,7 +92,6 @@ class Rule(object):
             Label to reference the meaning of this rule. Optional, but
             recommended.
         """
-        self.label = label
         self.aggregation_method = FuzzyAggregationMethod()
 
         self._antecedent = None
@@ -102,12 +101,18 @@ class Rule(object):
         if consequent is not None:
             self.consequent = consequent
 
+        if label is not None:
+            self.label = label
+        else:
+            self.label = id(self)
+
     def __repr__(self):
         """
         Concise, readable summary of the fuzzy rule.
         """
-        if self.label is not None:
-            return self.label
+        out = ""
+        if isinstance(self.label, str):
+            out += self.label + ": "
         if len(self.consequent) == 1:
             cons = self.consequent[0]
         else:

--- a/skfuzzy/control/state.py
+++ b/skfuzzy/control/state.py
@@ -5,7 +5,7 @@ class StatefulProperty(object):
 
     def __init__(self, initial_condition=None):
         self.default = initial_condition
-        self.data = {}
+        self.data = {'current': None}
 
     def __get__(self, instance, owner):
         if instance is None:
@@ -27,10 +27,15 @@ class StatePerSimulation(object):
 
     def __init__(self, initial_condition=None):
         self.default = initial_condition
-        self._sim_data = {}
+        self._sim_data = {'current': None}
 
     def __getitem__(self, key):
         from .controlsystem import ControlSystemSimulation
+
+        # Shortcut for current sim value, to carry across unique ID updates
+        if key == 'current':
+            return self._sim_data[key]
+
         assert isinstance(key, ControlSystemSimulation)
 
         # Access all state data via the unique identifier string
@@ -48,6 +53,12 @@ class StatePerSimulation(object):
 
     def __setitem__(self, key, value):
         from .controlsystem import ControlSystemSimulation
+
+        # Shortcut for current sim value, to carry across unique ID updates
+        if key == 'current':
+            self._sim_data[key] = value
+            return
+
         assert isinstance(key, ControlSystemSimulation)
 
         # Access all state data via the unique identifier string

--- a/skfuzzy/control/state.py
+++ b/skfuzzy/control/state.py
@@ -1,12 +1,11 @@
-
-from weakref import WeakKeyDictionary
+from __future__ import print_function, division
 
 
 class StatefulProperty(object):
 
-    def __init__(self, initial_condition = None):
+    def __init__(self, initial_condition=None):
         self.default = initial_condition
-        self.data = WeakKeyDictionary()
+        self.data = {}
 
     def __get__(self, instance, owner):
         if instance is None:
@@ -24,31 +23,34 @@ class StatefulProperty(object):
                              "Did you mean to access via a simultation?")
 
 
-
 class StatePerSimulation(object):
 
-    def __init__(self, initial_condition = None):
+    def __init__(self, initial_condition=None):
         self.default = initial_condition
-        self._sim_data = WeakKeyDictionary()
+        self._sim_data = {}
 
     def __getitem__(self, key):
         from .controlsystem import ControlSystemSimulation
         assert isinstance(key, ControlSystemSimulation)
+
+        # Access all state data via the unique identifier string
+        key_id = key.unique_id
         try:
-            return self._sim_data[key]
+            return self._sim_data[key_id]
         except KeyError:
             if isinstance(self.default, dict) and len(self.default) == 0:
                 # Create a new empty dictionary and remember it
                 result = dict()
-                self._sim_data[key] = result
+                self._sim_data[key_id] = result
                 return result
             else:
                 return self.default
 
-
     def __setitem__(self, key, value):
         from .controlsystem import ControlSystemSimulation
         assert isinstance(key, ControlSystemSimulation)
-        self._sim_data[key] = value
 
+        # Access all state data via the unique identifier string
+        key_id = key.unique_id
 
+        self._sim_data[key_id] = value

--- a/skfuzzy/control/state.py
+++ b/skfuzzy/control/state.py
@@ -5,7 +5,7 @@ class StatefulProperty(object):
 
     def __init__(self, initial_condition=None):
         self.default = initial_condition
-        self.data = {'current': None}
+        self.data = {'current': initial_condition}
 
     def __get__(self, instance, owner):
         if instance is None:

--- a/skfuzzy/control/state.py
+++ b/skfuzzy/control/state.py
@@ -27,7 +27,7 @@ class StatePerSimulation(object):
 
     def __init__(self, initial_condition=None):
         self.default = initial_condition
-        self._sim_data = {'current': None}
+        self._sim_data = {'current': initial_condition}
 
     def __getitem__(self, key):
         from .controlsystem import ControlSystemSimulation

--- a/skfuzzy/control/tests/test_controlsystem.py
+++ b/skfuzzy/control/tests/test_controlsystem.py
@@ -1,5 +1,7 @@
 from __future__ import division
 
+import sys
+
 import numpy as np
 import numpy.testing as tst
 import nose
@@ -85,6 +87,8 @@ def test_rule_order():
     assert resolved == [r1, r2, r3], "Order given was: %s" % resolved
 
 
+# The assert_raises decorator does not work in Python 2.6
+@tst.decorators.skipif(sys.version_info < (2, 7))
 @nose.with_setup(setup_rule_order)
 def test_unresolvable_rule_order():
     # Make sure we don't get suck in an infinite loop when the user

--- a/skfuzzy/control/tests/test_controlsystem.py
+++ b/skfuzzy/control/tests/test_controlsystem.py
@@ -68,7 +68,7 @@ def setup_rule_order():
     c = Antecedent(np.linspace(0, 10, 11), 'c')
     d = Antecedent(np.linspace(0, 10, 11), 'd')
 
-    for v in (a,b,c,d):
+    for v in (a, b, c, d):
         v.automf(3)
 
 

--- a/skfuzzy/control/tests/test_controlsystem.py
+++ b/skfuzzy/control/tests/test_controlsystem.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import numpy as np
 import numpy.testing as tst
 import nose
@@ -5,7 +7,6 @@ import nose
 from skfuzzy.control import (Antecedent, Consequent, Rule, ControlSystem,
                              ControlSystemSimulation)
 from skfuzzy import trimf
-from nose.tools import assert_raises
 
 
 def test_tipping_problem():
@@ -57,6 +58,7 @@ def test_bad_rules():
     not_rules = ['me', 192238, 42, dict()]
     tst.assert_raises(ValueError, ControlSystem, not_rules)
 
+
 def setup_rule_order():
     global a, b, c, d
     a = Antecedent(np.linspace(0, 10, 11), 'a')
@@ -66,6 +68,7 @@ def setup_rule_order():
 
     for v in (a,b,c,d):
         v.automf(3)
+
 
 @nose.with_setup(setup_rule_order)
 def test_rule_order():
@@ -81,6 +84,7 @@ def test_rule_order():
     resolved = list(ctrl.rules)
     assert resolved == [r1, r2, r3], "Order given was: %s" % resolved
 
+
 @nose.with_setup(setup_rule_order)
 def test_unresolvable_rule_order():
     # Make sure we don't get suck in an infinite loop when the user
@@ -91,9 +95,9 @@ def test_unresolvable_rule_order():
     r2 = Rule(c['poor'] | b['poor'], c['poor'], label='r2')
     r3 = Rule(c['good'] | a['good'], d['good'], label='r3')
 
-    ctrl = ControlSystem([r1, r2, r3])
     ex_msg = "Unable to resolve rule execution order"
-    with assert_raises(RuntimeError, expected_regexp=ex_msg):
+    with tst.assert_raises(RuntimeError, expected_regexp=ex_msg):
+        ctrl = ControlSystem([r1, r2, r3])
         list(ctrl.rules)
 
 if __name__ == '__main__':

--- a/skfuzzy/control/visualization.py
+++ b/skfuzzy/control/visualization.py
@@ -35,16 +35,16 @@ class FuzzyVariableVisualizer(object):
         """
         from .fuzzyvariable import FuzzyVariable, Term
 
-        assert (isinstance(fuzzy_var, FuzzyVariable) or
-                isinstance(fuzzy_var, Term))
-
         # self.term allows us to know if this is a Term quickly, later
         self.term = None
         if isinstance(fuzzy_var, Term):
             self.term = fuzzy_var.label
             self.fuzzy_var = fuzzy_var.parent_variable
-        else:
+        elif isinstance(fuzzy_var, FuzzyVariable):
             self.fuzzy_var = fuzzy_var
+        else:
+            raise ValueError("`FuzzyVariableVisualizer` can only be called "
+                             "with a `FuzzyVariable` or a `Term`.")
 
         self.fig, self.ax = plt.subplots()
         self.plots = {}


### PR DESCRIPTION
Closes #91.

Take a look, @jsexauer - I made some significant tweaks to the `StatePerSimulation` and `_InputAcceptor` to make this possible. In essence:

* `ControlSystemSimulation` objects now carry a `unique_id` property based on the `ControlSystem` object `id` and a hash of the current input values in an OrderedDict. If the underlying simulation doesn't change, this is unique to a given set of inputs. If the user sets the inputs back to a particular set of values, this is repeatable, which paves the way for caching (not yet fully implemented)
* All input data is stored and referenced via this unique ID instead of weak references to the simulation object. Dictionaries should stay small enough with ~32 char string keys that weakref shouldn't be needed, but a periodic flush might be required.
* _Current_ input data is stored initially in the `'current'` key. This is kind of a buffer; it doesn't trigger an update of the control system unique ID, so users can interactively set things all they like. Then, when calculation is desired, the current set of inputs can be found from 'current', used to generate a unique_id, pushed from the 'current' key to the unique ID key in StatePerSimulation objects, and computation proceeds.

This does seem to work, but if there's a more elegant way I'm all ears.

TODO: 
- [ ] The `unique_id` should probably be protected and/or hidden.
- [ ] Consider allowing caching to be turned off entirely for systems which are memory limited. In this instance the above machinery should be disabled and 'current' should be used as the unique ID.
- [ ] Translate my notebook example into a new gallery example, illustrating repeated calculations in a complicated system.