### PR TITLE
DOC: Make system too sparse error more informative.

### DIFF
--- a/skfuzzy/control/controlsystem.py
+++ b/skfuzzy/control/controlsystem.py
@@ -402,7 +402,15 @@ class CrispValueCalculator(object):
             raise ValueError("No terms have memberships.  Make sure you "
                              "have at least one rule connected to this "
                              "variable and have run the rules calculation.")
-        return defuzz(self.var.universe, output_mf, self.var.defuzzify_method)
+        try:
+            return defuzz(self.var.universe, output_mf,
+                          self.var.defuzzify_method)
+        except AssertionError:
+            raise ValueError("Crisp output cannot be calculated, likely "
+                             "because the system is too sparse. Check to "
+                             "make sure this set of input values will "
+                             "activate at least one connected Term in each "
+                             "Antecedent via the current set of Rules.")
 
     def fuzz(self, value):
         """


### PR DESCRIPTION
This partially addresses #82. I'd like to have a way to track the set of input values on each `FuzzyVariable`'s universe which are "covered" by each `Rule` as they get added to the system. Then we could tell the user where their rules have gaps, instead of just telling them to check their work.

However, the error raised in a situation where the inputs do not fire any Terms is now much more informative. It's acceptable at this point to ship 0.2.