### PR TITLE
New API cleanup and fix for #108

### DIFF
--- a/docs/examples/plot_tipping_problem_newapi.py
+++ b/docs/examples/plot_tipping_problem_newapi.py
@@ -55,12 +55,13 @@ start by defining the fuzzy variables that we use.
 """
 import numpy as np
 import skfuzzy as fuzz
+from skfuzzy import control as ctrl
 
 # New Antecedent/Consequent objects hold universe variables and membership
 # functions
-quality = fuzz.Antecedent(np.arange(0, 11, 1), 'quality')
-service = fuzz.Antecedent(np.arange(0, 11, 1), 'service')
-tip = fuzz.Consequent(np.arange(0, 26, 1), 'tip')
+quality = ctrl.Antecedent(np.arange(0, 11, 1), 'quality')
+service = ctrl.Antecedent(np.arange(0, 11, 1), 'service')
+tip = ctrl.Consequent(np.arange(0, 26, 1), 'tip')
 
 # Auto-membership function population is possible with .automf(3, 5, or 7)
 quality.automf(3)
@@ -106,9 +107,9 @@ imprecise rules into a defined, actionable tip is a challenge. This is the
 kind of task at which fuzzy logic excels.
 """
 
-rule1 = fuzz.Rule(quality['poor'] | service['poor'], tip['low'])
-rule2 = fuzz.Rule(service['average'], tip['medium'])
-rule3 = fuzz.Rule(service['good'] | quality['good'], tip['high'])
+rule1 = ctrl.Rule(quality['poor'] | service['poor'], tip['low'])
+rule2 = ctrl.Rule(service['average'], tip['medium'])
+rule3 = ctrl.Rule(service['good'] | quality['good'], tip['high'])
 
 rule1.view()
 
@@ -122,7 +123,7 @@ Now that we have our rules defined, we can simply create a control system
 via:
 """
 
-tipping_ctrl = fuzz.ControlSystem([rule1, rule2, rule3])
+tipping_ctrl = ctrl.ControlSystem([rule1, rule2, rule3])
 
 """
 In order to simulate this control system, we will create a
@@ -133,7 +134,7 @@ Sharon at the local brew-pub.  We would create another
 for Travis at the cafe because the inputs would be different.
 """
 
-tipping = fuzz.ControlSystemSimulation(tipping_ctrl)
+tipping = ctrl.ControlSystemSimulation(tipping_ctrl)
 
 """
 We can now simulate our control system by simply specifying the inputs

--- a/docs/tools/build_modref_templates.py
+++ b/docs/tools/build_modref_templates.py
@@ -35,7 +35,7 @@ if __name__ == '__main__':
     # are not (re)generated. This avoids automatic generation of documentation
     # for older or newer versions if such versions are installed on the system.
 
-    source_lines = open('../skimage/__init__.py').readlines()
+    source_lines = open('../skfuzzy/__init__.py').readlines()
     version = 'vUndefined'
     for l in source_lines:
         if l.startswith('__version__'):

--- a/skfuzzy/control/antecedent_consequent.py
+++ b/skfuzzy/control/antecedent_consequent.py
@@ -5,18 +5,13 @@ import numpy as np
 import networkx as nx
 
 from .state import StatefulProperty
-from ..fuzzymath import interp_membership
 from .fuzzyvariable import FuzzyVariable
-from ..defuzzify import defuzz
-
-try:
-    from collections import OrderedDict
-except ImportError:
-    from .ordereddict import OrderedDict
 
 
-
-def accu_max(*args):
+def _accu_max(*args):
+    """
+    Wrapper for fuzzy accumulation method.
+    """
     return np.max(args)
 
 
@@ -32,8 +27,8 @@ class Antecedent(FuzzyVariable):
     label : string
         Name of the universe variable.
     """
-    # Customized subclass of `FuzzyVariable`
 
+    # Customized subclass of `FuzzyVariable`
     input = StatefulProperty(None)
 
     def __init__(self, universe, label):
@@ -43,6 +38,9 @@ class Antecedent(FuzzyVariable):
 
     @property
     def graph(self):
+        """
+        NetworkX graph which connects this Antecedent with its Term(s).
+        """
         g = nx.DiGraph()
         for t in self.terms.values():
             g.add_path([self, t])
@@ -66,8 +64,8 @@ class Consequent(FuzzyVariable):
     The ``label`` string chosen must be unique among Antecedents and
     Consequents in the ``ControlSystem``.
     """
-    # Customized subclass of `FuzzyVariable`
 
+    # Customized subclass of `FuzzyVariable`
     output = StatefulProperty(None)
 
     def __init__(self, universe, label):
@@ -76,10 +74,13 @@ class Consequent(FuzzyVariable):
         self.__name__ = 'Consequent'
 
         # Default accumulation method is to take the max of any cut
-        self.accumulation_method = accu_max
+        self.accumulation_method = _accu_max
 
     @property
     def graph(self):
+        """
+        NetworkX graph which connects this Consequent with its Term(s).
+        """
         g = nx.DiGraph()
         for t in self.terms.values():
             g.add_path([t, self])

--- a/skfuzzy/control/controlsystem.py
+++ b/skfuzzy/control/controlsystem.py
@@ -7,10 +7,11 @@ import numpy as np
 import networkx as nx
 
 from skfuzzy import interp_membership, interp_universe, defuzz
+from .fuzzyvariable import FuzzyVariable
 from .antecedent_consequent import Antecedent, Consequent
-from .fuzzyvariable import FuzzyVariable, Term, TermAggregate
+from .term import Term, WeightedTerm, TermAggregate
+from .rule import Rule
 from .visualization import ControlSystemVisualizer
-from .rule import Rule, WeightedTerm
 
 try:
     from collections import OrderedDict

--- a/skfuzzy/control/controlsystem.py
+++ b/skfuzzy/control/controlsystem.py
@@ -203,11 +203,16 @@ class ControlSystemSimulation(object):
     cache : bool, optional
         Controls if results should be stored for reference in fuzzy variable
         objects, allowing fast lookup for repeated runs of `.compute()`.
-        If your system is small and accepts only integer inputs, consider
-        setting this `True`. For most other uses, leave this off (`False`).
+        Unless you are heavily memory constrained leave this `True` (default).
+    flush_after_run : int, optional
+        Clears cached results after this many repeated, unique simulations.
+        The default of 1000 is appropriate for most hardware, but for small
+        embedded systems this can be lowered as appropriate. Higher memory
+        systems may see better performance with a higher limit.
     """
 
-    def __init__(self, control_system, clip_to_bounds=True, cache=False):
+    def __init__(self, control_system, clip_to_bounds=True, cache=True,
+                 flush_after_run=1000):
         """
         Initialize a new ControlSystemSimulation.
         """ + '\n'.join(ControlSystemSimulation.__doc__.split('\n')[1:])
@@ -217,13 +222,13 @@ class ControlSystemSimulation(object):
         self.input = _InputAcceptor(self)
         self.output = OrderedDict()
         self.cache = cache
-        if self.cache is not True:
-            self.unique_id = 'current'
-        else:
-            self.unique_id = self._update_unique_id()
+        self.unique_id = self._update_unique_id()
 
         self.clip_to_bounds = clip_to_bounds
         self._calculated = []
+
+        self._run = 0
+        self._flush_after_run = flush_after_run
 
     def _update_unique_id(self):
         """
@@ -232,11 +237,6 @@ class ControlSystemSimulation(object):
         Generated at runtime from the system state. Used as key to access data
         from `StatePerSimulation` objects, enabling multiple runs.
         """
-        #
-        if self.cache is not True:
-            self.unique_id = 'current'
-            return
-
         # The string to be hashed is the concatenation of:
         #  * the control system ID, which is independent of inputs
         #  * hash of the current input OrderedDict
@@ -284,11 +284,14 @@ class ControlSystemSimulation(object):
             CrispValueCalculator(antecedent, self).fuzz(antecedent.input[self])
 
         # Calculate rules, taking inputs and accumulating outputs
+        first = True
         for rule in self.ctrl.rules:
             # Clear results of prior runs from Terms if needed.
-            if self.cache is not True:
+            if first:
                 for c in rule.consequent:
                     c.term.membership_value[self] = None
+                    c.activation[self] = None
+                first = False
             self.compute_rule(rule)
 
         # Collect the results and present them as a dict
@@ -300,6 +303,14 @@ class ControlSystemSimulation(object):
         # Make note of this run so we can easily find it again
         if self.cache is not False:
             self._calculated.append(self.unique_id)
+        else:
+            # Reset StatePerSimulations
+            self._reset_simulation()
+
+        # Increment run number
+        self._run += 1
+        if self._run % self._flush_after_run == 0:
+            self._reset_simulation()
 
     def compute_rule(self, rule):
         """
@@ -316,7 +327,6 @@ class ControlSystemSimulation(object):
         #  The process of actually aggregating everything is delegated to the
         #  TermAggregation class, but we can tell that class
         #  what aggregation style this rule mandates
-
         if isinstance(rule.antecedent, TermAggregate):
             rule.antecedent.agg_method = rule.aggregation_method
         rule.aggregate_firing[self] = rule.antecedent.membership_value[self]
@@ -344,11 +354,35 @@ class ControlSystemSimulation(object):
             else:
                 # Use the accumulation method of variable to determine
                 #  how to to handle multiple cuts
-                accu = term.parent_variable.accumulation_method
+                accu = term.parent.accumulation_method
                 term.membership_value[self] = accu(value,
                                                    term.membership_value[self])
 
-            term.cuts[self][rule.label] = value
+            term.cuts[self][rule.label] = term.membership_value[self]
+
+    def _reset_simulation(self):
+        """
+        Clear temporary data from simulation objects.
+
+        Called internally if cache=False (after every run) or after a certain
+        number of runs if cache=True according to the `flush_after_run` kwarg.
+        """
+        def _clear_terms(fuzzy_var):
+            for term in fuzzy_var.terms.itervalues():
+                term.membership_value.clear()
+                term.cuts.clear()
+
+        for rule in self.ctrl.rules:
+            rule.aggregate_firing.clear()
+            for c in rule.consequent:
+                c.activation.clear()
+
+        for consequent in self.ctrl.consequents:
+            consequent.output.clear()
+            _clear_terms(consequent)
+
+        self._calculated = []
+        self._run = 0
 
     def print_state(self):
         """
@@ -435,10 +469,12 @@ class CrispValueCalculator(object):
     def defuzz(self):
         """Derive crisp value based on membership of adjective(s)."""
         ups_universe, output_mf, cut_mfs = self.find_memberships()
+
         if len(cut_mfs) == 0:
             raise ValueError("No terms have memberships.  Make sure you "
                              "have at least one rule connected to this "
                              "variable and have run the rules calculation.")
+
         try:
             return defuzz(ups_universe, output_mf,
                           self.var.defuzzify_method)

--- a/skfuzzy/control/controlsystem.py
+++ b/skfuzzy/control/controlsystem.py
@@ -154,7 +154,7 @@ class _InputAcceptor(object):
         """
         current_inputs = self._get_inputs()
         out = ""
-        for key, val in current_inputs.iteritems():
+        for key, val in current_inputs.items():
             out += "{0} : {1}\n".format(key, val)
         return out
 
@@ -368,7 +368,7 @@ class ControlSystemSimulation(object):
         number of runs if cache=True according to the `flush_after_run` kwarg.
         """
         def _clear_terms(fuzzy_var):
-            for term in fuzzy_var.terms.itervalues():
+            for term in fuzzy_var.terms.values():
                 term.membership_value.clear()
                 term.cuts.clear()
 

--- a/skfuzzy/control/fuzzyvariable.py
+++ b/skfuzzy/control/fuzzyvariable.py
@@ -92,7 +92,7 @@ class FuzzyVariable(object):
         if isinstance(item, Term):
             if item.label != key:
                 raise ValueError("Term's label must match new key")
-            if item.parent_variable is not None:
+            if item.parent is not None:
                 raise ValueError("Term must not already have a parent")
         else:
             # Try to create a term from item, assuming it is a membership
@@ -112,7 +112,7 @@ class FuzzyVariable(object):
                              "range. Allowed range is [0, 1].".format(key))
 
         # If above pass, add the new membership function
-        item.parent_variable = self
+        item.parent = self
         self.terms[key] = item
 
     def view(self, *args, **kwargs):

--- a/skfuzzy/control/fuzzyvariable.py
+++ b/skfuzzy/control/fuzzyvariable.py
@@ -2,165 +2,15 @@
 fuzzyvariable.py : Contains the base fuzzy variable class, FuzzyVariable.
 """
 import numpy as np
-import matplotlib.pyplot as plt
 
 from ..membership import trimf
 from .visualization import FuzzyVariableVisualizer
-from .state import StatefulProperty
+from .term import Term
 
 try:
     from collections import OrderedDict
 except ImportError:
     from .ordereddict import OrderedDict
-
-
-class TermPrimitive(object):
-    """
-    Marker class for type checking when a term or term aggregate is expected.
-    """
-    pass
-
-    def membership_value(self):
-        raise NotImplementedError("Implement in concrete class")
-
-    def __and__(self, other):
-        if not isinstance(other, TermPrimitive):
-            raise ValueError("Can only construct 'AND' from the term "
-                             "of a fuzzy variable")
-
-        return TermAggregate(self, other, 'and')
-
-    def __or__(self, other):
-        if not isinstance(other, TermPrimitive):
-            raise ValueError("Can only construct 'OR' from the term "
-                             "of a fuzzy variable")
-
-        return TermAggregate(self, other, 'or')
-
-    def __invert__(self):
-        return TermAggregate(self, None, 'not')
-
-
-class Term(TermPrimitive):
-    """
-    A Term is a universe and associated specific membership function.
-
-    For example, if one were creating a FuzzyVariable with a simple three-point
-    liker scale, three `Term` would be created: poor, average, and good.
-    """
-
-    # State variables
-    membership_value = StatefulProperty(None)
-    cuts = StatefulProperty({})
-
-    def __init__(self, label, membership_function):
-        super(Term, self).__init__()
-        self.label = label
-        self.parent_variable = None
-        self.mf = membership_function
-
-    @property
-    def full_label(self):
-        """Term with parent.  Ex: velocity['fast']"""
-        if self.parent_variable is None:
-            raise ValueError("This term must be bound to a parent first")
-        return self.parent_variable.label + "[" + self.label + "]"
-
-    def view(self, *args, **kwargs):
-        """""" + FuzzyVariableVisualizer.view.__doc__
-        fig, ax = FuzzyVariableVisualizer(self).view(*args, **kwargs)
-        fig.show()
-
-    def __repr__(self):
-        return self.full_label
-
-    def __mod__(self, other):
-        from .rule import WeightedTerm
-        assert isinstance(other, float)
-        return WeightedTerm(self, other)
-
-
-class FuzzyAggregationMethod(object):
-    def __init__(self, and_func=min, or_func=max):
-        # Default and to OR = max and AND = min
-        self.and_agg_func = and_func
-        self.or_agg_func = or_func
-
-
-class _MembershipValueAccessor(object):
-
-    def __init__(self, agg):
-        assert isinstance(agg, TermAggregate)
-        self.agg = agg
-
-    def __getitem__(self, key):
-        from .controlsystem import ControlSystemSimulation
-        assert isinstance(key, ControlSystemSimulation)
-        # Perform aggregation to determine membership
-        term1 = self.agg.term1.membership_value[key]
-        if self.agg.term2 is not None:
-            term2 = self.agg.term2.membership_value[key]
-
-        if self.agg.kind == 'and':
-            return self.agg.agg_method.and_agg_func(
-                term1, term2)
-        elif self.agg.kind == 'or':
-            return self.agg.agg_method.or_agg_func(
-                term1, term2)
-        elif self.agg.kind == 'not':
-            return 1. - self.agg.term1.membership_value[key]
-        else:
-            raise NotImplementedError()
-
-
-class TermAggregate(TermPrimitive):
-    """
-    Used to track the creation of AND and OR clauses used when building
-    the antecedent of a rule.
-    """
-
-    def __init__(self, term1, term2, kind):
-        assert isinstance(term1, TermPrimitive)
-        if kind in ('and', 'or'):
-            assert isinstance(term2, TermPrimitive)
-        elif kind == 'not':
-            assert term2 is None, "NOT (~) operates on a single Term, not two."
-        else:
-            raise ValueError("Unexpected kind")
-
-        self.term1 = term1
-        self.term2 = term2
-        self.kind = kind
-        self._agg_method = FuzzyAggregationMethod()
-        self.membership_value = _MembershipValueAccessor(self)
-
-    def __repr__(self):
-        def _term_to_str(term):
-            if isinstance(term, Term):
-                return term.full_label
-            elif isinstance(term, TermAggregate):
-                return "(%s)" % term
-
-        if self.kind == 'not':
-            return "NOT-%s" % _term_to_str(self.term1)
-
-        return "%s %s %s" % (_term_to_str(self.term1), self.kind.upper(),
-                             _term_to_str(self.term2))
-
-    @property
-    def agg_method(self):
-        return self._agg_method
-
-    @agg_method.setter
-    def agg_method(self, value):
-        if not isinstance(value, FuzzyAggregationMethod):
-            raise ValueError("Expected FuzzyAggregationMethod")
-        self._agg_method = value
-
-        # Propegate agg method down to all agg terms below me
-        for term in (self.term1, self.term2):
-            if isinstance(term, TermAggregate):
-                term.agg_method = value
 
 
 class FuzzyVariable(object):
@@ -235,8 +85,7 @@ class FuzzyVariable(object):
 
     def __setitem__(self, key, item):
         """
-        Enables new membership functions or term to be added with the
-        syntax::
+        Enable terms to be added with the syntax::
 
           variable['new_label'] = new_mf
         """
@@ -274,7 +123,7 @@ class FuzzyVariable(object):
     def automf(self, number=5, variable_type='quality', names=None,
                invert=False):
         """
-        Automatically populates the universe with membership functions.
+        Automatically populate the universe with membership functions.
 
         Parameters
         ----------

--- a/skfuzzy/control/rule.py
+++ b/skfuzzy/control/rule.py
@@ -7,45 +7,10 @@ with conqeuents in a `ControlSystem`.
 from __future__ import print_function, division
 
 import networkx as nx
-from .fuzzyvariable import (FuzzyAggregationMethod, Term,
-                            TermAggregate, TermPrimitive)
-from .visualization import ControlSystemVisualizer
+from .term import (Term, WeightedTerm, TermAggregate, FuzzyAggregationMethod,
+                   TermPrimitive)
 from .state import StatefulProperty
-
-
-class WeightedTerm(object):
-    """
-    A `Term`, with a weight assigned.
-
-    All consequents become `WeightedTerm`s in calculation; if a weight
-    was not assigned, they default to a weight of 1.0.
-    """
-
-    activation = StatefulProperty(None)
-
-    def __init__(self, term, weight=1.0):
-        """
-        Initialize the weighted consequent.
-
-        Parameters
-        ----------
-        term : Term
-            A fuzzy variable with specified mebership function.
-        weight : float
-            Weight to assign this Term
-        """
-        assert isinstance(term, Term)
-        self.term = term
-        self.weight = weight
-
-    def __repr__(self):
-        """
-        String representation of the `WeightedTerm`.
-        """
-        if self.weight == 1.:
-            return self.term.full_label
-        else:
-            return "%s@%0.2f%%" % (self.term.full_label, self.weight)
+from .visualization import ControlSystemVisualizer
 
 
 class Rule(object):

--- a/skfuzzy/control/rule.py
+++ b/skfuzzy/control/rule.py
@@ -77,13 +77,11 @@ class Rule(object):
         """
         Concise, readable summary of the fuzzy rule.
         """
-        out = ""
-        if isinstance(self.label, str):
-            out += self.label + ": "
         if len(self.consequent) == 1:
             cons = self.consequent[0]
         else:
             cons = self.consequent
+
         return "IF %s THEN %s" % (self.antecedent, cons)
 
     @property
@@ -137,15 +135,16 @@ class Rule(object):
     @consequent.setter
     def consequent(self, value):
         """
-        Accepts consequents in four formats:
+        Accept consequents in four formats:
+
          a) Unweighted single output.
-            eg: output['term']
+            e.g.: output['term']
          b) Weighted single output
-            eg: (output['term']%0.5)
+            e.g.: (output['term']%0.5)
          c) Unweighted multiple output
-            eg: (output1['term1'], output2['term2'])
+            e.g.: (output1['term1'], output2['term2'])
          d) Weighted multiple output
-            eg: ( (output1['term1']%1.0), (output2['term2']%0.5) )
+            e.g.: ( (output1['term1']%1.0), (output2['term2']%0.5) )
         """
         if isinstance(value, Term):
             self._consequent = [WeightedTerm(value, 1.)]
@@ -179,13 +178,13 @@ class Rule(object):
         for t in self.antecedent_terms:
             assert isinstance(t, Term)
             graph.add_path([t, self])
-            graph = nx.compose(graph, t.parent_variable.graph)
+            graph = nx.compose(graph, t.parent.graph)
 
         # Link all consequents from me
         for c in self.consequent:
             assert isinstance(c, WeightedTerm)
             graph.add_path([self, c.term])
-            graph = nx.compose(graph, c.term.parent_variable.graph)
+            graph = nx.compose(graph, c.term.parent.graph)
         return graph
 
     def view(self):

--- a/skfuzzy/control/state.py
+++ b/skfuzzy/control/state.py
@@ -1,3 +1,12 @@
+"""
+state.py : Contains framework to hold variables unique to a simulation.
+
+This allows simulations to be precalculated and then referenced later for a
+dramatic efficiency gain. This gain is only realized for smaller systems,
+usually with discrete-valued inputs. However, if your controller can contain
+all possible input states in memory and repeat values are likely, enabling
+caching will result in major efficiency gains.
+"""
 from __future__ import print_function, division
 
 

--- a/skfuzzy/control/state.py
+++ b/skfuzzy/control/state.py
@@ -31,6 +31,9 @@ class StatefulProperty(object):
         raise AttributeError("Property is read-only. "
                              "Did you mean to access via a simultation?")
 
+    def clear(self, initial_condition=None):
+        self.__init__(self.default)
+
 
 class StatePerSimulation(object):
 
@@ -71,6 +74,7 @@ class StatePerSimulation(object):
         assert isinstance(key, ControlSystemSimulation)
 
         # Access all state data via the unique identifier string
-        key_id = key.unique_id
+        self._sim_data[key.unique_id] = value
 
-        self._sim_data[key_id] = value
+    def clear(self, initial_condition=None):
+        self.__init__(self.default)

--- a/skfuzzy/control/term.py
+++ b/skfuzzy/control/term.py
@@ -1,0 +1,198 @@
+"""
+term.py : Contains framework to create fuzzy terms.
+
+Most notably, contains the `Term` and `WeightedTerm` objects which are used to
+identify specific membership functions attached to Antecedents or
+Consequents when constructing fuzzy Rules.
+
+Terms have redefined logical operators which enable the simple and elegant
+combination of several during Rule creation.
+"""
+from __future__ import print_function, division
+
+from .visualization import FuzzyVariableVisualizer
+from .state import StatefulProperty
+
+
+class TermPrimitive(object):
+    """
+    Marker class for type checking when a term or term aggregate is expected.
+    """
+
+    def membership_value(self):
+        raise NotImplementedError("Implement in concrete class")
+
+    def __and__(self, other):
+        if not isinstance(other, TermPrimitive):
+            raise ValueError("Can only construct 'AND' from the term "
+                             "of a fuzzy variable")
+
+        return TermAggregate(self, other, 'and')
+
+    def __or__(self, other):
+        if not isinstance(other, TermPrimitive):
+            raise ValueError("Can only construct 'OR' from the term "
+                             "of a fuzzy variable")
+
+        return TermAggregate(self, other, 'or')
+
+    def __invert__(self):
+        return TermAggregate(self, None, 'not')
+
+
+class Term(TermPrimitive):
+    """
+    A Term is a universe and associated specific membership function.
+
+    For example, if one were creating a FuzzyVariable with a simple three-
+    point liker scale, three `Term` would be created named poor, average,
+    and good.
+    """
+
+    # State variables
+    membership_value = StatefulProperty(None)
+    cuts = StatefulProperty({})
+
+    def __init__(self, label, membership_function):
+        super(Term, self).__init__()
+        self.label = label
+        self.parent = None
+        self.mf = membership_function
+
+    @property
+    def full_label(self):
+        """Term with parent.  Ex: velocity['fast']"""
+        if self.parent is None:
+            raise ValueError("This term must be bound to a parent first")
+        return self.parent.label + "[" + self.label + "]"
+
+    def view(self, *args, **kwargs):
+        """""" + FuzzyVariableVisualizer.view.__doc__
+        fig, ax = FuzzyVariableVisualizer(self).view(*args, **kwargs)
+        fig.show()
+
+    def __repr__(self):
+        return self.full_label
+
+    def __mod__(self, other):
+        from .rule import WeightedTerm
+        assert isinstance(other, float)
+        return WeightedTerm(self, other)
+
+
+class WeightedTerm(object):
+    """
+    A `Term`, with a weight assigned.
+
+    All consequents become `WeightedTerm`s in calculation; if a weight
+    was not assigned, they default to a weight of 1.0.
+    """
+
+    activation = StatefulProperty(None)
+
+    def __init__(self, term, weight=1.0):
+        """
+        Initialize the weighted consequent.
+
+        Parameters
+        ----------
+        term : Term
+            A fuzzy variable with specified mebership function.
+        weight : float
+            Weight to assign this Term
+        """
+        assert isinstance(term, Term)
+        self.term = term
+        self.weight = weight
+
+    def __repr__(self):
+        """
+        String representation of the `WeightedTerm`.
+        """
+        if self.weight == 1.:
+            return self.term.full_label
+        else:
+            return "%s@%0.2f%%" % (self.term.full_label, self.weight)
+
+
+class FuzzyAggregationMethod(object):
+    def __init__(self, and_func=min, or_func=max):
+        # Default and to OR = max and AND = min
+        self.and_agg_func = and_func
+        self.or_agg_func = or_func
+
+
+class _MembershipValueAccessor(object):
+
+    def __init__(self, agg):
+        assert isinstance(agg, TermAggregate)
+        self.agg = agg
+
+    def __getitem__(self, key):
+        from .controlsystem import ControlSystemSimulation
+        assert isinstance(key, ControlSystemSimulation)
+        # Perform aggregation to determine membership
+        term1 = self.agg.term1.membership_value[key]
+        if self.agg.term2 is not None:
+            term2 = self.agg.term2.membership_value[key]
+
+        if self.agg.kind == 'and':
+            return self.agg.agg_method.and_agg_func(
+                term1, term2)
+        elif self.agg.kind == 'or':
+            return self.agg.agg_method.or_agg_func(
+                term1, term2)
+        elif self.agg.kind == 'not':
+            return 1. - self.agg.term1.membership_value[key]
+        else:
+            raise NotImplementedError()
+
+
+class TermAggregate(TermPrimitive):
+    """
+    Used to track the creation of AND and OR clauses used when building
+    the antecedent of a rule.
+    """
+
+    def __init__(self, term1, term2, kind):
+        assert isinstance(term1, TermPrimitive)
+        if kind in ('and', 'or'):
+            assert isinstance(term2, TermPrimitive)
+        elif kind == 'not':
+            assert term2 is None, "NOT (~) operates on a single Term, not two."
+        else:
+            raise ValueError("Unexpected kind")
+
+        self.term1 = term1
+        self.term2 = term2
+        self.kind = kind
+        self._agg_method = FuzzyAggregationMethod()
+        self.membership_value = _MembershipValueAccessor(self)
+
+    def __repr__(self):
+        def _term_to_str(term):
+            if isinstance(term, Term):
+                return term.full_label
+            elif isinstance(term, TermAggregate):
+                return "(%s)" % term
+
+        if self.kind == 'not':
+            return "NOT-%s" % _term_to_str(self.term1)
+
+        return "%s %s %s" % (_term_to_str(self.term1), self.kind.upper(),
+                             _term_to_str(self.term2))
+
+    @property
+    def agg_method(self):
+        return self._agg_method
+
+    @agg_method.setter
+    def agg_method(self, value):
+        if not isinstance(value, FuzzyAggregationMethod):
+            raise ValueError("Expected FuzzyAggregationMethod")
+        self._agg_method = value
+
+        # Propegate agg method down to all agg terms below me
+        for term in (self.term1, self.term2):
+            if isinstance(term, TermAggregate):
+                term.agg_method = value

--- a/skfuzzy/control/term.py
+++ b/skfuzzy/control/term.py
@@ -131,6 +131,7 @@ class _MembershipValueAccessor(object):
     def __getitem__(self, key):
         from .controlsystem import ControlSystemSimulation
         assert isinstance(key, ControlSystemSimulation)
+
         # Perform aggregation to determine membership
         term1 = self.agg.term1.membership_value[key]
         if self.agg.term2 is not None:

--- a/skfuzzy/control/tests/test_controlsystem.py
+++ b/skfuzzy/control/tests/test_controlsystem.py
@@ -6,40 +6,39 @@ import numpy as np
 import numpy.testing as tst
 import nose
 
-from skfuzzy.control import (Antecedent, Consequent, Rule, ControlSystem,
-                             ControlSystemSimulation)
-from skfuzzy import trimf
+import skfuzzy as fuzz
+import skfuzzy.control as ctrl
 
 
 def test_tipping_problem():
     # The full tipping problem uses many of these methods
-    food = Antecedent(np.linspace(0, 10, 11), 'quality')
-    service = Antecedent(np.linspace(0, 10, 11), 'service')
-    tip = Consequent(np.linspace(0, 25, 26), 'tip')
+    food = ctrl.Antecedent(np.linspace(0, 10, 11), 'quality')
+    service = ctrl.Antecedent(np.linspace(0, 10, 11), 'service')
+    tip = ctrl.Consequent(np.linspace(0, 25, 26), 'tip')
 
     food.automf(3)
     service.automf(3)
 
     # Manual membership function definition
-    tip['bad'] = trimf(tip.universe, [0, 0, 13])
-    tip['middling'] = trimf(tip.universe, [0, 13, 25])
-    tip['lots'] = trimf(tip.universe, [13, 25, 25])
+    tip['bad'] = fuzz.trimf(tip.universe, [0, 0, 13])
+    tip['middling'] = fuzz.trimf(tip.universe, [0, 13, 25])
+    tip['lots'] = fuzz.trimf(tip.universe, [13, 25, 25])
 
     # Define fuzzy rules
-    rule1 = Rule(food['poor'] | service['poor'], tip['bad'])
-    rule2 = Rule(service['average'], tip['middling'])
-    rule3 = Rule(service['good'] | food['good'], tip['lots'])
+    rule1 = ctrl.Rule(food['poor'] | service['poor'], tip['bad'])
+    rule2 = ctrl.Rule(service['average'], tip['middling'])
+    rule3 = ctrl.Rule(service['good'] | food['good'], tip['lots'])
 
     # The control system - defined both possible ways
-    tipping = ControlSystem([rule1, rule2, rule3])
+    tipping = ctrl.ControlSystem([rule1, rule2, rule3])
 
-    tipping2 = ControlSystem()
+    tipping2 = ctrl.ControlSystem()
     tipping2.addrule(rule2)
     tipping2.addrule(rule3)
     tipping2.addrule(rule1)
 
-    tip_sim = ControlSystemSimulation(tipping)
-    tip_sim2 = ControlSystemSimulation(tipping2)
+    tip_sim = ctrl.ControlSystemSimulation(tipping)
+    tip_sim2 = ctrl.ControlSystemSimulation(tipping2)
 
     # Inputs added both possible ways
     inputs = {'quality': 6.5, 'service': 9.8}
@@ -52,21 +51,26 @@ def test_tipping_problem():
     tip_sim.compute()
     tip_sim2.compute()
 
-    assert tip_sim.output == tip_sim2.output
+    # Ensure both methods of defining rules yield the same results
+    for val0, val1 in zip(tip_sim.output.itervalues(),
+                          tip_sim2.output.itervalues()):
+        tst.assert_allclose(val0, val1)
+
+    # Verify against manual computation
     tst.assert_allclose(tip_sim.output['tip'], 19.8578, atol=1e-2, rtol=1e-2)
 
 
 def test_bad_rules():
     not_rules = ['me', 192238, 42, dict()]
-    tst.assert_raises(ValueError, ControlSystem, not_rules)
+    tst.assert_raises(ValueError, ctrl.ControlSystem, not_rules)
 
 
 def setup_rule_order():
     global a, b, c, d
-    a = Antecedent(np.linspace(0, 10, 11), 'a')
-    b = Antecedent(np.linspace(0, 10, 11), 'b')
-    c = Antecedent(np.linspace(0, 10, 11), 'c')
-    d = Antecedent(np.linspace(0, 10, 11), 'd')
+    a = ctrl.Antecedent(np.linspace(0, 10, 11), 'a')
+    b = ctrl.Antecedent(np.linspace(0, 10, 11), 'b')
+    c = ctrl.Antecedent(np.linspace(0, 10, 11), 'c')
+    d = ctrl.Antecedent(np.linspace(0, 10, 11), 'd')
 
     for v in (a, b, c, d):
         v.automf(3)
@@ -78,12 +82,12 @@ def test_rule_order():
     #  correctly
     global a, b, c, d
 
-    r1 = Rule(a['average'] | a['poor'], c['poor'], label='r1')
-    r2 = Rule(c['poor'] | b['poor'], c['good'], label='r2')
-    r3 = Rule(c['good'] | a['good'], d['good'], label='r3')
+    r1 = ctrl.Rule(a['average'] | a['poor'], c['poor'], label='r1')
+    r2 = ctrl.Rule(c['poor'] | b['poor'], c['good'], label='r2')
+    r3 = ctrl.Rule(c['good'] | a['good'], d['good'], label='r3')
 
-    ctrl = ControlSystem([r1, r2, r3])
-    resolved = list(ctrl.rules)
+    ctrl_sys = ctrl.ControlSystem([r1, r2, r3])
+    resolved = list(ctrl_sys.rules)
     assert resolved == [r1, r2, r3], "Order given was: %s" % resolved
 
 
@@ -95,14 +99,85 @@ def test_unresolvable_rule_order():
     #  gives an unresolvable rule order
     global a, b, c, d
 
-    r1 = Rule(a['average'] | a['poor'], c['poor'], label='r1')
-    r2 = Rule(c['poor'] | b['poor'], c['poor'], label='r2')
-    r3 = Rule(c['good'] | a['good'], d['good'], label='r3')
+    r1 = ctrl.Rule(a['average'] | a['poor'], c['poor'], label='r1')
+    r2 = ctrl.Rule(c['poor'] | b['poor'], c['poor'], label='r2')
+    r3 = ctrl.Rule(c['good'] | a['good'], d['good'], label='r3')
 
     ex_msg = "Unable to resolve rule execution order"
     with tst.assert_raises(RuntimeError, expected_regexp=ex_msg):
-        ctrl = ControlSystem([r1, r2, r3])
-        list(ctrl.rules)
+        ctrl_sys = ctrl.ControlSystem([r1, r2, r3])
+        list(ctrl_sys.rules)
+
+
+def test_multiple_rules_same_consequent_term():
+    # 2 input variables, 1 output variable and 7 instances.
+    x1_inputs = [0.6, 0.2, 0.4, 0.7, 1, 1.2, 1.8]
+    x2_inputs = [0.9, 1, 0.8, 0, 1.2, 0.6, 1.8]
+
+    dom = np.arange(0, 2.1, 0.01)
+    x1 = ctrl.Antecedent(dom, "x1")
+    x1['label0'] = fuzz.trimf(x1.universe, (0.2, 0.2, 0.6))
+    x1['label1'] = fuzz.trimf(x1.universe, (0.2, 0.6, 1.0))
+    x1['label2'] = fuzz.trimf(x1.universe, (0.6, 1.0, 1.4))
+    x1['label3'] = fuzz.trimf(x1.universe, (1.0, 1.4, 1.8))
+    x1['label4'] = fuzz.trimf(x1.universe, (1.4, 1.8, 1.8))
+
+    x2 = ctrl.Antecedent(dom, "x2")
+    x2['label0'] = fuzz.trimf(x2.universe, (0.0, 0.0, 0.45))
+    x2['label1'] = fuzz.trimf(x2.universe, (0.0, 0.45, 0.9))
+    x2['label2'] = fuzz.trimf(x2.universe, (0.45, 0.9, 1.35))
+    x2['label3'] = fuzz.trimf(x2.universe, (0.9, 1.35, 1.8))
+    x2['label4'] = fuzz.trimf(x2.universe, (1.35, 1.8, 1.8))
+
+    y = ctrl.Consequent(dom, "y")
+    y['label0'] = fuzz.trimf(y.universe, (0.3, 0.3, 0.725))
+    y['label1'] = fuzz.trimf(y.universe, (0.3, 0.725, 1.15))
+    y['label2'] = fuzz.trimf(y.universe, (0.725, 1.15, 1.575))
+    y['label3'] = fuzz.trimf(y.universe, (1.15, 1.575, 2.0))
+    y['label4'] = fuzz.trimf(y.universe, (1.575, 2.0, 2.0))
+
+    r1 = ctrl.Rule(x1['label0'] & x2['label2'], y['label0'])
+    r2 = ctrl.Rule(x1['label1'] & x2['label0'], y['label0'])
+    r3 = ctrl.Rule(x1['label1'] & x2['label2'], y['label0'])
+
+    # Equivalent to above 3 rules
+    r123 = ctrl.Rule((x1['label0'] & x2['label2']) |
+                     (x1['label1'] & x2['label0']) |
+                     (x1['label1'] & x2['label2']), y['label0'])
+
+    r4 = ctrl.Rule(x1['label2'] & x2['label1'], y['label2'])
+    r5 = ctrl.Rule(x1['label2'] & x2['label3'], y['label3'])
+    r6 = ctrl.Rule(x1['label4'] & x2['label4'], y['label4'])
+
+    # Build a system with three rules targeting the same Consequent Term,
+    # and then an equivalent system with those three rules combined into one.
+    cs0 = ctrl.ControlSystem([r1, r2, r3, r4, r5, r6])
+    cs1 = ctrl.ControlSystem([r123, r4, r5, r6])
+
+    expected_results = [0.438372093023,
+                        0.443962536855,
+                        0.461436409933,
+                        0.445290345769,
+                        1.575,
+                        1.15,
+                        1.86162790698]
+
+    # Ensure the results are equivalent within error
+    for inst, expected in zip(range(7), expected_results):
+        sim0 = ctrl.ControlSystemSimulation(cs0)
+        sim1 = ctrl.ControlSystemSimulation(cs1)
+
+        sim0.input["x1"] = x1_inputs[inst]
+        sim0.input["x2"] = x2_inputs[inst]
+        sim1.input["x1"] = x1_inputs[inst]
+        sim1.input["x2"] = x2_inputs[inst]
+
+        sim0.compute()
+        sim1.compute()
+
+        tst.assert_allclose(sim0.output['y'], sim1.output['y'])
+        tst.assert_allclose(expected, sim0.output['y'], atol=1e-4, rtol=1e-4)
+
 
 if __name__ == '__main__':
     tst.run_module_suite()

--- a/skfuzzy/control/tests/test_controlsystem.py
+++ b/skfuzzy/control/tests/test_controlsystem.py
@@ -52,8 +52,8 @@ def test_tipping_problem():
     tip_sim2.compute()
 
     # Ensure both methods of defining rules yield the same results
-    for val0, val1 in zip(tip_sim.output.itervalues(),
-                          tip_sim2.output.itervalues()):
+    for val0, val1 in zip(tip_sim.output.values(),
+                          tip_sim2.output.values()):
         tst.assert_allclose(val0, val1)
 
     # Verify against manual computation

--- a/skfuzzy/control/visualization.py
+++ b/skfuzzy/control/visualization.py
@@ -39,7 +39,7 @@ class FuzzyVariableVisualizer(object):
         self.term = None
         if isinstance(fuzzy_var, Term):
             self.term = fuzzy_var.label
-            self.fuzzy_var = fuzzy_var.parent_variable
+            self.fuzzy_var = fuzzy_var.parent
         elif isinstance(fuzzy_var, FuzzyVariable):
             self.fuzzy_var = fuzzy_var
         else:

--- a/skfuzzy/defuzzify/tests/test_defuzz.py
+++ b/skfuzzy/defuzzify/tests/test_defuzz.py
@@ -3,6 +3,25 @@ import skfuzzy as fuzz
 from numpy.testing import assert_allclose, assert_raises
 
 
+def test_bisector():
+    x = np.arange(6)
+    mfx = fuzz.trimf(x, [0, 5, 5])
+    expected = 3.53553390593274
+
+    # Test both triangle code paths
+    assert_allclose(expected, fuzz.defuzz(x, mfx, 'bisector'))
+    assert_allclose(5 - expected, fuzz.defuzz(x, 1 - mfx, 'bisector'))
+
+    # Test singleton input
+    y = np.r_[2]
+    mfy = np.r_[0.33]
+    assert_allclose(y, fuzz.defuzz(y, mfy, 'bisector'))
+
+    # Test rectangle code path
+    mfx = fuzz.trapmf(x, [2, 2, 4, 4])
+    assert_allclose(3., fuzz.defuzz(x, mfx, 'bisector'))
+
+
 def test_centroid():
 
     def helper_centroid(mean=0, sigma=1):
@@ -24,6 +43,23 @@ def test_centroid():
             helper_centroid(mean, sigma)
             for differential_centroid in 42 * (np.arange(11) - 5):
                 helper_dcentroid(mean, sigma, differential_centroid)
+
+    # Test with ends @ zero, to evaluate special cases in new defuzz method
+    x = np.arange(21) - 10
+    gmf = fuzz.gaussmf(x, 0, np.pi)
+    gmf[0] = 0
+    gmf[-1] = 0
+    assert_allclose(0, fuzz.centroid(x, gmf), atol=1e-8)
+
+
+def test_centroid_singleton():
+    x = np.r_[0]
+    mfx = np.r_[0]
+    assert_allclose(np.r_[0], fuzz.centroid(x, mfx))
+
+    x = np.r_[3]
+    mfx = np.r_[0.5]
+    assert_allclose(x, fuzz.centroid(x, mfx))
 
 
 def test_defuzz():

--- a/skfuzzy/fuzzymath/tests/test_fuzzy_ops.py
+++ b/skfuzzy/fuzzymath/tests/test_fuzzy_ops.py
@@ -428,39 +428,42 @@ def test_sigmoid():
     assert_allclose(test, expected)
 
 
-def test_partial_dmf():
-
-    gaussmf = 'gaussmf'
+def test_partial_dmf_gauss():
+    name = 'gaussmf'
     mean = -1.5
     sigma = 0.75
     gaussmf_param_dict = {'mean': mean,
                           'sigma': sigma}
     test_int = randint(1, 3)
 
-    gaussmf_results = [partial_dmf(-1.5, gaussmf, gaussmf_param_dict, 'mean'),
-                       partial_dmf(-1.5, gaussmf, gaussmf_param_dict, 'sigma'),
-                       partial_dmf(-1.5, gaussmf, {'mean': mean, 'sigma': test_int * sigma}, 'mean') ==
-                       -partial_dmf(-1.5, gaussmf, {'mean': mean, 'sigma': -test_int * sigma}, 'mean')]
+    gaussmf_results = [partial_dmf(-1.5, name, gaussmf_param_dict, 'mean'),
+                       partial_dmf(-1.5, name, gaussmf_param_dict, 'sigma'),
+                       partial_dmf(-1.5, name, {'mean': mean, 'sigma': test_int * sigma}, 'mean') ==
+                       -partial_dmf(-1.5, name, {'mean': mean, 'sigma': -test_int * sigma}, 'mean')]
     gaussmf_expected = [0., 0., True]
     assert_allclose(gaussmf_results, gaussmf_expected)
 
-    gbellmf = 'gbellmf'
+
+def test_partial_dmf_gbell():
+    name = 'gbellmf'
     a = 2.
     b = 1.
     c = 0.5
     gbellmf_param_dict = {'a': a, 'b': b, 'c': c}
 
-    gbellmf_results = [partial_dmf(-1.5, gbellmf, gbellmf_param_dict, 'a'),
-                       partial_dmf(2.5, gbellmf, gbellmf_param_dict, 'a'),
-                       partial_dmf(-1.5, gbellmf, gbellmf_param_dict, 'b'),
-                       partial_dmf(2.5, gbellmf, gbellmf_param_dict, 'b'),
-                       partial_dmf(-1.5, gbellmf, gbellmf_param_dict, 'c'),
-                       partial_dmf(2.5, gbellmf, gbellmf_param_dict, 'c')
+    gbellmf_results = [partial_dmf(-1.5, name, gbellmf_param_dict, 'a'),
+                       partial_dmf(2.5, name, gbellmf_param_dict, 'a'),
+                       partial_dmf(-1.5, name, gbellmf_param_dict, 'b'),
+                       partial_dmf(2.5, name, gbellmf_param_dict, 'b'),
+                       partial_dmf(-1.5, name, gbellmf_param_dict, 'c'),
+                       partial_dmf(2.5, name, gbellmf_param_dict, 'c')
                        ]
     gbellmf_expected = [0.25, 0.25, -0.0, -0.0, -0.25, 0.25]
     assert_allclose(gbellmf_results, gbellmf_expected)
 
-    sigmf = 'sigmf'
+
+def test_partial_dmf_sigmoid():
+    name = 'sigmf'
     b_one = 1.0
     c_one = 3.0
     b_two = -1.0
@@ -468,10 +471,10 @@ def test_partial_dmf():
     sigmf_param_dict_one = {'b': b_one, 'c': c_one}
     sigmf_param_dict_two = {'b': b_two, 'c': c_two}
 
-    sigmf_results = [partial_dmf(1.0, sigmf, sigmf_param_dict_one, 'b'),
-                     partial_dmf(-1.0, sigmf, sigmf_param_dict_two, 'b'),
-                     partial_dmf(1.0, sigmf, sigmf_param_dict_one, 'c'),
-                     partial_dmf(-1.0, sigmf, sigmf_param_dict_two, 'c')
+    sigmf_results = [partial_dmf(1.0, name, sigmf_param_dict_one, 'b'),
+                     partial_dmf(-1.0, name, sigmf_param_dict_two, 'b'),
+                     partial_dmf(1.0, name, sigmf_param_dict_one, 'c'),
+                     partial_dmf(-1.0, name, sigmf_param_dict_two, 'c')
                      ]
     sigmf_expected = [-0.75, -0.125, 0., 0.]
     assert_allclose(sigmf_results, sigmf_expected)


### PR DESCRIPTION
This is a combination of several fixes which have been in the pipeline for 0.2.

* Multiple Rules may now point at the same Consequent, closing #108.
* New `flush_after_run` kwarg added to `ControlSystemSimulation`, allowing a given system to be 'sized to fit' memory by users.
* Caching now defaults on (`cache=True`), because memory can be controlled by setting `flush_after_run`.
* All infrastructure associated with Terms refactored into a separate file, `term.py`, and imports adjusted accordingly.
* Test suite improvements with regression tests for #108 and additional coverage.
* Documentation improvements.