### PR TITLE
Drop testing on Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ python:
 env:
     - ENV="python=2.6 numpy=1.6"
     - ENV="python=2.7 numpy"
-    - ENV="python=3.3 numpy"
     - ENV="python=3.4 numpy"
     - ENV="python=3.5 numpy"
 


### PR DESCRIPTION
NumPy / SciPy have a strange error with this portion of the test matrix. Almost nobody on the 3.x branch is using 3.3 or earlier, so this PR drops Python 3.3 from the test matrix.