### PR TITLE
FIX: Fix memory leak on repeated simulations. Closes #119.

### DIFF
--- a/skfuzzy/control/controlsystem.py
+++ b/skfuzzy/control/controlsystem.py
@@ -381,6 +381,10 @@ class ControlSystemSimulation(object):
             consequent.output.clear()
             _clear_terms(consequent)
 
+        for antecedent in self.ctrl.antecedents:
+            antecedent.input.clear()
+            _clear_terms(antecedent)
+
         self._calculated = []
         self._run = 0
 


### PR DESCRIPTION
Cached `Antecedent` inputs weren't being cleared. This caused the memory leak reported in #119.