### PR TITLE
Incorporates out of range values

### DIFF
--- a/skfuzzy/fuzzymath/fuzzy_ops.py
+++ b/skfuzzy/fuzzymath/fuzzy_ops.py
@@ -643,20 +643,23 @@ def interp_membership(x, xmf, xx):
 
     """
     # Nearest discrete x-values
-    x1 = x[x <= xx][-1]
-    x2 = x[x >= xx][0]
+    if (x[-1] > x[0] and x[0] < xx < x[-1]) or (x[-1] < x[0] and x[-1] < xx < x[0]):
+        x1 = x[x <= xx][-1]
+        x2 = x[x >= xx][0]
 
-    idx1 = np.nonzero(x == x1)[0][0]
-    idx2 = np.nonzero(x == x2)[0][0]
+        idx1 = np.nonzero(x == x1)[0][0]
+        idx2 = np.nonzero(x == x2)[0][0]
 
-    xmf1 = xmf[idx1]
-    xmf2 = xmf[idx2]
+        xmf1 = xmf[idx1]
+        xmf2 = xmf[idx2]
 
-    if x1 == x2:
-        xxmf = xmf[idx1]
+        if x1 == x2:
+            xxmf = xmf[idx1]
+        else:
+            slope = (xmf2 - xmf1) / float(x2 - x1)
+            xxmf = slope * (xx - x1) + xmf1
     else:
-        slope = (xmf2 - xmf1) / float(x2 - x1)
-        xxmf = slope * (xx - x1) + xmf1
+        xxmf = 0.0
 
     return xxmf
 

--- a/skfuzzy/fuzzymath/fuzzy_ops.py
+++ b/skfuzzy/fuzzymath/fuzzy_ops.py
@@ -661,8 +661,8 @@ def interp_membership(x, xmf, xx):
         
         return xxmf
       
-    except IndexError,e:
-        if 'out of bounds for axis 0 with size 0' in e.message:
+    except IndexError as e:
+        if 'out of bounds for axis 0 with size 0' in str(e):
             return 0.0
  
 

--- a/skfuzzy/fuzzymath/fuzzy_ops.py
+++ b/skfuzzy/fuzzymath/fuzzy_ops.py
@@ -643,7 +643,7 @@ def interp_membership(x, xmf, xx):
 
     """
     # Nearest discrete x-values
-    if (x[-1] > x[0] and x[0] <= xx <= x[-1]) or (x[-1] < x[0] and x[-1] <= xx <= x[0]):
+    try:
         x1 = x[x <= xx][-1]
         x2 = x[x >= xx][0]
 
@@ -658,10 +658,13 @@ def interp_membership(x, xmf, xx):
         else:
             slope = (xmf2 - xmf1) / float(x2 - x1)
             xxmf = slope * (xx - x1) + xmf1
-    else:
-        xxmf = 0.0
-
-    return xxmf
+        
+        return xxmf
+      
+    except IndexError,e:
+        if 'out of bounds for axis 0 with size 0' in e.message:
+            return 0.0
+ 
 
 
 def interp_universe(x, xmf, y):

--- a/skfuzzy/fuzzymath/fuzzy_ops.py
+++ b/skfuzzy/fuzzymath/fuzzy_ops.py
@@ -643,7 +643,7 @@ def interp_membership(x, xmf, xx):
 
     """
     # Nearest discrete x-values
-    if (x[-1] > x[0] and x[0] < xx < x[-1]) or (x[-1] < x[0] and x[-1] < xx < x[0]):
+    if (x[-1] > x[0] and x[0] <= xx <= x[-1]) or (x[-1] < x[0] and x[-1] <= xx <= x[0]):
         x1 = x[x <= xx][-1]
         x2 = x[x >= xx][0]
 


### PR DESCRIPTION
Currently, a value out of the range of the set will throw an error as line x[x <= xx][-1] in the interp_membership function returns an empty list. (The value being compared is not in the range of the 1D array denoted by x)

This particular change will circumvent that issue and return 0.0 indicating that the membership is 0 for that set.