### PR TITLE
ENH: Return both figure and axis for ControlSystemVisualizer

### DIFF
--- a/skfuzzy/control/visualization.py
+++ b/skfuzzy/control/visualization.py
@@ -165,4 +165,4 @@ class ControlSystemVisualizer(object):
         View the visualization.
         """
         nx.draw(self.ctrl.graph, ax=self.ax)
-        return self.fig
+        return self.fig, self.ax


### PR DESCRIPTION
Previously only the figure was returned.  Now both the figure and axis objects are returned, which is more consistent and extensible.