### PR TITLE
Add docs for 'defuzzify_method' as a parameter in FuzzyVariable

### DIFF
--- a/skfuzzy/control/antecedent_consequent.py
+++ b/skfuzzy/control/antecedent_consequent.py
@@ -69,6 +69,8 @@ class Consequent(FuzzyVariable):
         array.
     label : string
         Name of the universe variable.
+    defuzzify_method : string
+        name of method used for defuzzification, defaults to 'centroid'
 
     Notes
     -----
@@ -79,9 +81,9 @@ class Consequent(FuzzyVariable):
     # Customized subclass of `FuzzyVariable`
     output = StatefulProperty(None)
 
-    def __init__(self, universe, label):
+    def __init__(self, universe, label, defuzzify_method='centroid'):
         """""" + Consequent.__doc__
-        super(Consequent, self).__init__(universe, label)
+        super(Consequent, self).__init__(universe, label, defuzzify_method)
         self.__name__ = 'Consequent'
 
         # Default accumulation method is to take the max of any cut

--- a/skfuzzy/control/fuzzyvariable.py
+++ b/skfuzzy/control/fuzzyvariable.py
@@ -24,7 +24,8 @@ class FuzzyVariable(object):
         array. Required.
     label : string
         Name of the universe variable. Optional.
-
+    defuzzify_method : string
+        name of method used for defuzzification, defaults to 'centroid'
     Methods
     -------
 

--- a/skfuzzy/control/tests/test_fuzzyvariables.py
+++ b/skfuzzy/control/tests/test_fuzzyvariables.py
@@ -69,6 +69,23 @@ def test_instantiate_consequent():
     assert con.__repr__() == 'Consequent: {0}'.format(label)
 
 
+def test_instantiate_consequent_different_defuzzify_method():
+    # Correctly create a minimal Consequent
+    universe = np.linspace(0, 5, 7)
+    label = 'test-Consequent Labeling ??$%&dwlkj234!"'
+    defuzzify_method = 'bisector'
+    con = Consequent(universe, label, defuzzify_method)
+
+    # Assure expected behavior
+    tst.assert_equal(universe, con.universe)
+    assert con.label == label
+    assert con._id == id(con)
+    assert_empty_ordereddict(con.terms)
+    assert con.__name__ == 'Consequent'
+    assert con.__repr__() == 'Consequent: {0}'.format(label)
+    assert con.defuzzify_method == defuzzify_method
+
+
 @nose.with_setup(setup)
 def test_automf3():
     global ant  # universe: [0, 1, 2, 3, 4, 5]


### PR DESCRIPTION
Hi, I was searching a bit how I could set a different defuzzyfication method in the Consequent, and I couldn't find this in the docs. After digging a bit, I found that it was done simply by passing the `defuzzify_method` in the instantiation. 
So I thought that this may help out other people (I'm not sure, but I believe that if someone do a "search" in the docs, it will appear this in the FuzzyVariable).

If you believe it's handy, I can also add this to the Consequent's doc.