### PR TITLE
Minor point release - 0.3.1

### DIFF
--- a/skfuzzy/__init__.py
+++ b/skfuzzy/__init__.py
@@ -14,7 +14,7 @@ Recommended Use
 """
 __all__ = []
 
-__version__ = '0.4dev'
+__version__ = '0.3.1'
 
 ######################
 # Subpackage imports #

--- a/skfuzzy/control/tests/test_controlsystem.py
+++ b/skfuzzy/control/tests/test_controlsystem.py
@@ -83,7 +83,7 @@ def test_rule_order():
     r3 = ctrl.Rule(c['good'] | a['good'], d['good'], label='r3')
 
     ctrl_sys = ctrl.ControlSystem([r1, r2, r3])
-    resolved = [l.label for l in ctrl_sys.rules]
+    resolved = [r for r in ctrl_sys.rules]
     assert resolved == [r1, r2, r3], "Order given was: {0}, expected {1}".format(
       resolved, [r1.label, r2.label, r3.label])
 

--- a/skfuzzy/control/tests/test_controlsystem.py
+++ b/skfuzzy/control/tests/test_controlsystem.py
@@ -71,6 +71,7 @@ def setup_rule_order():
         v.automf(3)
 
 
+@tst.decorators.skipif(float(networkx.__version__) >= 2.0)
 @nose.with_setup(setup_rule_order)
 def test_rule_order():
     # Make sure rules are exposed in the order needed to solve them
@@ -82,9 +83,9 @@ def test_rule_order():
     r3 = ctrl.Rule(c['good'] | a['good'], d['good'], label='r3')
 
     ctrl_sys = ctrl.ControlSystem([r1, r2, r3])
-    resolved = list(ctrl_sys.rules)
+    resolved = [l.label for l in ctrl_sys.rules]
     assert resolved == [r1, r2, r3], "Order given was: {0}, expected {1}".format(
-      resolved, [r1, r2, r3])
+      resolved, [r1.label, r2.label, r3.label])
 
 
 # The assert_raises decorator does not work in Python 2.6
@@ -106,7 +107,6 @@ def test_unresolvable_rule_order():
         list(ctrl_sys.rules)
 
 
-@tst.decorators.skipif(float(networkx.__version__) >= 2.0)
 @nose.with_setup(setup_rule_order)
 def test_bad_rules():
     not_rules = ['me', 192238, 42, dict()]


### PR DESCRIPTION
This minor point release brings a significant new feature and minor fixes/compatibility enhancements:

Major feature:

* Arrays are now accepted as system inputs; all inputs must have the same shape.  The output matches this shape.  This is dramatically more computationally efficient for repeated runs on existing data - within the limits of your system memory. (see #141)

Minor fixes

* Fixed the mathematical definition of `skfuzzy.gaussmf`; this is a potentially breaking change but the results are now correct (see #147)
* NetworkX 2.0 forward compatibility (see #149 and #150)
* Improve and harmonize the `.view()` methods in `skfuzzy.control` (see #142 and #148)
* Update examples to use the above