### PR TITLE
Numerically safe normalization of columns exponentiated to large powers.

### DIFF
--- a/skfuzzy/cluster/_cmeans.py
+++ b/skfuzzy/cluster/_cmeans.py
@@ -6,7 +6,7 @@ from scipy.spatial.distance import cdist
 from .normalize_columns import normalize_columns, normalize_power_columns
 
 
-def _cmeans0(data, u_old, c, m, safe):
+def _cmeans0(data, u_old, c, m):
     """
     Single step in generic fuzzy c-means clustering algorithm.
 
@@ -31,10 +31,7 @@ def _cmeans0(data, u_old, c, m, safe):
 
     jm = (um * d ** 2).sum()
 
-    if safe:
-        u = normalize_power_columns(d, - 2. / (m - 1))
-    else:
-        u = normalize_columns(d**(- 2. / (m - 1)))
+    u = normalize_power_columns(d, - 2. / (m - 1))
 
     return cntr, u, jm, d
 
@@ -84,7 +81,7 @@ def _fp_coeff(u):
     return np.trace(u.dot(u.T)) / float(n)
 
 
-def cmeans(data, c, m, error, maxiter, init=None, seed=None, safe=False):
+def cmeans(data, c, m, error, maxiter, init=None, seed=None):
     """
     Fuzzy c-means clustering algorithm [1].
 
@@ -108,9 +105,6 @@ def cmeans(data, c, m, error, maxiter, init=None, seed=None, safe=False):
     seed : int
         If provided, sets random seed of init. No effect if init is
         provided. Mainly for debug/testing purposes.
-    safe : bool
-        Will try to do calculations in a numerically safe way. About
-        two to three times slower.
 
     Returns
     -------
@@ -169,7 +163,7 @@ def cmeans(data, c, m, error, maxiter, init=None, seed=None, safe=False):
     # Main cmeans loop
     while p < maxiter - 1:
         u2 = u.copy()
-        [cntr, u, Jjm, d] = _cmeans0(data, u2, c, m, safe)
+        [cntr, u, Jjm, d] = _cmeans0(data, u2, c, m)
         jm = np.hstack((jm, Jjm))
         p += 1
 
@@ -226,9 +220,6 @@ def cmeans_predict(test_data, cntr_trained, m, error, maxiter, init=None,
         Number of iterations run.
     fpc : float
         Final fuzzy partition coefficient.
-    safe : bool
-        Will try to do calculations in a numerically safe way. About
-        two to three times slower.
 
     Notes
     -----
@@ -262,7 +253,7 @@ def cmeans_predict(test_data, cntr_trained, m, error, maxiter, init=None,
     # Main cmeans loop
     while p < maxiter - 1:
         u2 = u.copy()
-        [u, Jjm, d] = _cmeans_predict0(test_data, cntr_trained, u2, c, m, safe)
+        [u, Jjm, d] = _cmeans_predict0(test_data, cntr_trained, u2, c, m)
         jm = np.hstack((jm, Jjm))
         p += 1
 
@@ -277,7 +268,7 @@ def cmeans_predict(test_data, cntr_trained, m, error, maxiter, init=None,
     return u, u0, d, jm, p, fpc
 
 
-def _cmeans_predict0(test_data, cntr, u_old, c, m, safe):
+def _cmeans_predict0(test_data, cntr, u_old, c, m):
     """
     Single step in fuzzy c-means prediction algorithm. Clustering algorithm
     modified from Ross, Fuzzy Logic w/Engineering Applications (2010)
@@ -304,9 +295,6 @@ def _cmeans_predict0(test_data, cntr, u_old, c, m, safe):
 
     jm = (um * d ** 2).sum()
 
-    if safe:
-        u = normalize_power_columns(d, - 2. / (m - 1))
-    else:
-        u = normalize_columns(d**(- 2. / (m - 1)))
+    u = normalize_power_columns(d, - 2. / (m - 1))
 
     return u, jm, d

--- a/skfuzzy/cluster/_cmeans.py
+++ b/skfuzzy/cluster/_cmeans.py
@@ -179,7 +179,7 @@ def cmeans(data, c, m, error, maxiter, init=None, seed=None):
 
 
 def cmeans_predict(test_data, cntr_trained, m, error, maxiter, init=None,
-                   seed=None, safe=False):
+                   seed=None):
     """
     Prediction of new data in given a trained fuzzy c-means framework [1].
 

--- a/skfuzzy/cluster/normalize_columns.py
+++ b/skfuzzy/cluster/normalize_columns.py
@@ -46,6 +46,8 @@ def normalize_power_columns(x, exponent):
     """
 
     assert np.all(x >= 0.0)
+
+    x = x.astype(np.float64)
     
     # values in range [0, 1]
     x = x/np.max(x, axis=0, keepdims=True)

--- a/skfuzzy/cluster/normalize_columns.py
+++ b/skfuzzy/cluster/normalize_columns.py
@@ -4,6 +4,7 @@ _normalize_columns.py : Normalize columns.
 
 import numpy as np
 
+
 def normalize_columns(columns):
     """
     Normalize columns of matrix.
@@ -23,6 +24,7 @@ def normalize_columns(columns):
     normalized_columns = columns/np.sum(columns, axis=0, keepdims=1)
     
     return normalized_columns
+
 
 def normalize_power_columns(x, exponent):
     """

--- a/skfuzzy/cluster/normalize_columns.py
+++ b/skfuzzy/cluster/normalize_columns.py
@@ -1,0 +1,70 @@
+"""
+_normalize_columns.py : Normalize columns.
+"""
+
+import numpy as np
+
+def normalize_columns(columns):
+    """
+    Normalize columns of matrix.
+
+    Parameters
+    ----------
+    columns : 2d array (M x N)
+        Matrix with columns
+
+    Returns
+    -------
+    normalized_columns : 2d array (M x N)
+        columns/np.sum(columns, axis=0, keepdims=1)
+    """
+
+    # broadcast sum over columns
+    normalized_columns = columns/np.sum(columns, axis=0, keepdims=1)
+    
+    return normalized_columns
+
+def normalize_power_columns(x, exponent):
+    """
+    Calculate normalize_columns(x**exponent)
+    in a numerically safe manner.
+
+    Parameters
+    ----------
+    x : 2d array (M x N)
+        Matrix with columns
+    n : float
+        Exponent
+
+    Returns
+    -------
+    result : 2d array (M x N)
+        normalize_columns(x**n) but safe
+    
+    """
+
+    # works better for positive exponents
+    if exponent < 0:
+        exponent = -exponent
+        x = 1.0/x
+
+    # y = a**n/(a**n + b**n)
+    # 
+    # is equivalent to:
+    #
+    # p = exp(n*log(a) - n*log(m))
+    # q = exp(n*log(b) - n*log(m))
+    # y = p/(p + q)
+    # 
+    # where m is a positive number
+    #
+    # see:
+    # http://www.wolframalpha.com/input/?i=p%2F(p+%2B+q)+where+p+%3D+exp(n*log(a)+-+n*log(m))+and+q+%3D+exp(n*log(b)+-+n*log(m))
+    
+    columns = np.exp(exponent*np.log(x) -
+        exponent*np.log(np.max(x, axis=0, keepdims=1)))
+    
+    # calculate sum of each column, then normalize column by its sum
+    result = normalize_columns(columns)
+
+    return result

--- a/skfuzzy/cluster/tests/test_cmeans.py
+++ b/skfuzzy/cluster/tests/test_cmeans.py
@@ -124,6 +124,7 @@ def test_fuzzy_cmeans_predict():
     # Assert data points are correctly labeled (must harden U for comparison)
     np.testing.assert_array_equal(cluster, U.argmax(axis=0))
 
+
 @nose.with_setup(setup)
 def test_fuzzy_cmeans_predict_numerically():
     """

--- a/skfuzzy/cluster/tests/test_cmeans.py
+++ b/skfuzzy/cluster/tests/test_cmeans.py
@@ -124,6 +124,53 @@ def test_fuzzy_cmeans_predict():
     # Assert data points are correctly labeled (must harden U for comparison)
     np.testing.assert_array_equal(cluster, U.argmax(axis=0))
 
+@nose.with_setup(setup)
+def test_fuzzy_cmeans_predict_numerically():
+    """
+    Test ability to classify new data in a numerically safe manner.
+
+    """
+    global features
+    global x_corr
+    global y_corr
+
+    m = 1.0001
+
+    # Generate slightly smaller new dataset, clustered tighter around seeds
+    xtest = np.zeros(0)
+    ytest = np.zeros(0)
+    cluster = np.zeros(0)
+
+    # Given this initialization, the clustering will be [1, 2, 0]
+    for x, y, label in zip(x_corr, y_corr, [1, 2, 0]):
+        xtest = np.concatenate((xtest, np.r_[np.random.normal(x, 0.05, 100)]))
+        ytest = np.concatenate((ytest, np.r_[np.random.normal(y, 0.05, 100)]))
+        cluster = np.concatenate((cluster, np.r_[[label] * 100]))
+
+    test_data = np.c_[xtest, ytest].T
+
+    # Cluster the data to obtain centers
+    cntr, _, _, _, _, _, _ = fuzz.cluster.cmeans(
+        features, 3, m, error=0.005, maxiter=1000, init=None, safe=True)
+
+    # Predict fuzzy memberships, U, for all points in test_data, twice with
+    # set seed
+    U, _, _, _, _, fpc = fuzz.cluster.cmeans_predict(
+        test_data, cntr, m, error=0.005, maxiter=1000, seed=1234, safe=True)
+
+    U2, _, _, _, _, fpc2 = fuzz.cluster.cmeans_predict(
+        test_data, cntr, m, error=0.005, maxiter=1000, seed=1234, safe=True)
+
+    # Verify results are identical
+    assert fpc == fpc2
+    np.testing.assert_array_equal(U, U2)
+
+    # For this perfect dataset, fpc should be very high
+    assert fpc > 0.99
+
+    # Assert data points are correctly labeled (must harden U for comparison)
+    np.testing.assert_array_equal(cluster, U.argmax(axis=0))
+
 
 if __name__ == '__main__':
     np.testing.run_module_suite()

--- a/skfuzzy/cluster/tests/test_cmeans.py
+++ b/skfuzzy/cluster/tests/test_cmeans.py
@@ -152,15 +152,15 @@ def test_fuzzy_cmeans_predict_numerically():
 
     # Cluster the data to obtain centers
     cntr, _, _, _, _, _, _ = fuzz.cluster.cmeans(
-        features, 3, m, error=0.005, maxiter=1000, init=None, safe=True)
+        features, 3, m, error=0.005, maxiter=1000, init=None)
 
     # Predict fuzzy memberships, U, for all points in test_data, twice with
     # set seed
     U, _, _, _, _, fpc = fuzz.cluster.cmeans_predict(
-        test_data, cntr, m, error=0.005, maxiter=1000, seed=1234, safe=True)
+        test_data, cntr, m, error=0.005, maxiter=1000, seed=1234)
 
     U2, _, _, _, _, fpc2 = fuzz.cluster.cmeans_predict(
-        test_data, cntr, m, error=0.005, maxiter=1000, seed=1234, safe=True)
+        test_data, cntr, m, error=0.005, maxiter=1000, seed=1234)
 
     # Verify results are identical
     assert fpc == fpc2

--- a/skfuzzy/cluster/tests/test_normalize_columns.py
+++ b/skfuzzy/cluster/tests/test_normalize_columns.py
@@ -1,0 +1,79 @@
+import nose
+import numpy as np
+from skfuzzy.cluster.normalize_columns import normalize_power_columns
+
+
+def test_normalize_power_columns():
+    """
+    Test normalize_power_columns
+    """
+
+    a = np.array([
+        [0, 1, 1, 3],
+        [0, 0, 1, 3],
+        [1, 1, 1, 3],
+        [0, 0, 1, 3],
+    ])
+
+    a_normalized_expected = np.array([
+        [0.0, 0.5, 0.25, 0.25],
+        [0.0, 0.0, 0.25, 0.25],
+        [1.0, 0.5, 0.25, 0.25],
+        [0.0, 0.0, 0.25, 0.25],
+    ])
+
+    a_normalized = normalize_power_columns(a, 1)
+
+    np.testing.assert_allclose(a_normalized, a_normalized_expected, atol=1e-10)
+
+    b = np.array([
+        [0, 1e-100],
+        [1, 1e-100],
+        [1, 0.0000],
+    ])
+    
+    b_normalized_expected = np.array([
+        [0.0, 0.5],
+        [0.5, 0.5],
+        [0.5, 0.0],
+    ])
+
+    b_normalized = normalize_power_columns(b, 1)
+
+    np.testing.assert_allclose(b_normalized, b_normalized_expected, atol=1e-10)
+
+    c = np.array([
+        [0, 1e-100, 0, 1e100],
+        [1, 1e-100, 1, 1],
+        [1, 0.0000, 2, 0],
+    ])
+    
+    c_normalized_expected = np.array([
+        [0.0, 0.5, 0.0, 1],
+        [0.5, 0.5, 0.0, 0],
+        [0.5, 0.0, 1.0, 0],
+    ])
+
+    c_normalized = normalize_power_columns(c, 1000)
+
+    np.testing.assert_allclose(c_normalized, c_normalized_expected, atol=1e-10)
+    
+    d = np.array([
+        [0, 1e-100, 0, 1e100],
+        [1, 1e-100, 1, 1],
+        [1, 0.0000, 2, 0],
+    ])
+    
+    d_normalized_expected = np.array([
+        [1.0, 0.0, 1.0, 0.0],
+        [0.0, 0.0, 0.0, 0.5],
+        [0.0, 1.0, 0.0, 0.5],
+    ])
+
+    d_normalized = normalize_power_columns(d, -1000)
+
+    np.testing.assert_allclose(d_normalized, d_normalized_expected, atol=1e-10)
+
+
+if __name__ == '__main__':
+    np.testing.run_module_suite()


### PR DESCRIPTION
`cmeans` and `cmeans_predict` fail for values of `m` close to 1, for example 1.0001 [at this point in the code.](https://github.com/99991/scikit-fuzzy/blob/52a53157a0d42833a8a0277d59ca61c0de7df392/skfuzzy/cluster/_cmeans.py#L33)
It will expand to `d**-20000` which explodes for `d < 1`.

With some logarithms and exps this can be fixed, but comes at the cost of two to three times slower execution, so I made this enhancement optional. It can be enabled by passing `safe=True` to `cmeans` and `cmeans_predict`.