### PR TITLE
Fixed lom/som for negative ranges

### DIFF
--- a/skfuzzy/defuzzify/defuzz.py
+++ b/skfuzzy/defuzzify/defuzz.py
@@ -257,12 +257,10 @@ def defuzz(x, mfx, mode):
         return np.mean(x[mfx == mfx.max()])
 
     elif 'som' in mode:
-        tmp = x[mfx == mfx.max()]
-        return tmp[tmp == np.abs(tmp).min()][0]
+        return np.min(x[mfx == mfx.max()])
 
     elif 'lom' in mode:
-        tmp = x[mfx == mfx.max()]
-        return tmp[tmp == np.abs(tmp).max()][0]
+        return np.max(x[mfx == mfx.max()])
 
     else:
         raise ValueError('The input for `mode`, %s, was incorrect.' % (mode))

--- a/skfuzzy/defuzzify/tests/test_defuzz.py
+++ b/skfuzzy/defuzzify/tests/test_defuzz.py
@@ -79,6 +79,12 @@ def test_defuzz():
     assert_allclose(5, fuzz.defuzz(x, trapmf, 'mom'))
     assert_allclose(7, fuzz.defuzz(x, trapmf, 'lom'))
 
+
+    # Make sure som/lom work for all-negative universes:
+    x_neg = x-20
+    assert_allclose(-17, fuzz.defuzz(x_neg, trapmf, 'som'))
+    assert_allclose(-13, fuzz.defuzz(x_neg, trapmf, 'lom'))
+    
     # Bad string argument
     assert_raises(ValueError, fuzz.defuzz, x, trapmf, 'bad string')
 


### PR DESCRIPTION
This is a minor edit for issue #188: the lom/som defuzzification calculations used to apply abs() to their index sets, leading to a problem with all-negative universes.  

Fixed their definition to look more like the mom defuzzification method, and augmented the test-cases to include one with all-negative universes.

James.