### PR TITLE
Solve problems with pipenv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,33 +76,11 @@ def configuration(parent_package='', top_path=None):
 if __name__ == "__main__":
     try:
         from numpy.distutils.core import setup
-        extra = {'configuration': configuration}
-        # Do not try and upgrade larger dependencies
-        for lib in ['numpy', 'scipy', 'matplotlib']:
-            try:
-                __import__(lib)
-                INSTALL_REQUIRES = [i for i in INSTALL_REQUIRES
-                                    if lib not in i]
-            except ImportError:
-                pass
     except ImportError:
-        if len(sys.argv) >= 2 and ('--help' in sys.argv[1:] or
-                                   sys.argv[1] in ('--help-commands',
-                                                   '--version',
-                                                   'clean')):
-            # For these actions, NumPy is not required.
-            #
-            # They are required to succeed without Numpy for example when
-            # pip is used to install scikit-image when Numpy is not yet
-            # present in the system.
-            from setuptools import setup
-            extra = {}
-        else:
-            print('To install scikit-fuzzy from source, you will need numpy.\n' +
-                  'Install numpy with pip:\n' +
-                  'pip install numpy\n'
-                  'Or use your operating system package manager.')
-            sys.exit(1)
+        from setuptools import setup
+        extra = {}
+    else:
+        extra = {'configuration': configuration}
 
     setup(
         name=DISTNAME,


### PR DESCRIPTION
pipenv fails to install `scikit-fuzzy` on a clean environment with the following error:

```bash
$ pipenv install scikit-fuzzy
Installing scikit-fuzzy…
Collecting scikit-fuzzy
  Using cached https://files.pythonhosted.org/packages/09/36/4938f22f99ea415ef6b9f831b36057e1cb6bac3783f35a54a99da97eb5ff/scikit-fuzzy-0.4.0.tar.gz
    Complete output from command python setup.py egg_info:
    To install scikit-fuzzy from source, you will need numpy.
    Install numpy with pip:
    pip install numpy
    Or use your operating system package manager.
    
    ----------------------------------------

Error:  An error occurred while installing scikit-fuzzy!
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-ojxdtv4u/scikit-fuzzy/

This is likely caused by a bug in scikit-fuzzy. Report this to its maintainers.
```

This patch solves this problem removing some of the code in `setup.py`