### PR TITLE
FIX: Python 3.7 compatibility with PEP 479.

### DIFF
--- a/skfuzzy/control/controlsystem.py
+++ b/skfuzzy/control/controlsystem.py
@@ -155,7 +155,6 @@ class _InputAcceptor(object):
     If they are arrays, all must have the exact same shape.  If they are
     arrays, the output(s) will carry the same shape as the inputs.
     """
-
     def __init__(self, simulation):
         assert isinstance(simulation, ControlSystemSimulation)
         self.sim = simulation
@@ -772,7 +771,7 @@ class RuleOrderGenerator(object):
 
         if len(skipped_rules) == 0:
             # All done!
-            raise StopIteration()
+            return
         else:
             if len(skipped_rules) == len_rules:
                 # Avoid being caught in an infinite loop


### PR DESCRIPTION
This small patch resolves #202.

However, in testing something in Python 3.7 has resulted in significant performance regression related to prior versions.  The test suite prior to this patch and with this patch runs in about 1.8 seconds on this laptop, on Python 3.6 and prior.  Under Python 3.7 the suite takes 2.8 seconds, and the entire increase in runtime is related to the complex system test.

Because the performance with the patch is unaffected in Python 3.6, this major performance regression was introduced with Python 3.7 specifically.  Please take note of this; if performance is important, users should remain on Python 3.6.