### PR TITLE
ENH: Relax restriction on number of mfs in automf.

### DIFF
--- a/skfuzzy/control/fuzzyvariable.py
+++ b/skfuzzy/control/fuzzyvariable.py
@@ -128,17 +128,19 @@ class FuzzyVariable(object):
 
         Parameters
         ----------
-        number : [3, 5, 7] or list of names
-            Number of membership functions to create. Must be an odd integer.
-            At present, only 3, 5, or 7 are supported.
-            If a list of names is given, then those are used
+        number : integer or list of names
+            Number of membership functions to create. For fully automated use,
+            supply 3, 5, or 7.  Any number may be generated, if you provide
+            an appropriately sized list of `names`.  If names are provided,
+            they are used in lieu of the default names below.
         variable_type : string
             Type of variable this is. Accepted arguments are
             * 'quality' : Continuous variable, higher values are better.
             * 'quant' : Quantitative variable, no value judgements.
         names : list
             List of names to use when creating mebership functions if you wish
-            to override the default. Naming proceeds from lowest to highest.
+            to override the default. Naming proceeds from lowest to highest,
+            unless invert is True.
         invert : bool
             Reverses the naming order if True. Membership function peaks still
             march from lowest to highest.
@@ -178,7 +180,20 @@ class FuzzyVariable(object):
                 raise ValueError("Must provide an odd number of names")
         else:
             if number not in [3, 5, 7]:
-                raise ValueError("Only number = 3, 5, or 7 supported.")
+                try:
+                    if len(names) != number:
+                        raise ValueError("If number is not 3, 5, or 7, "
+                                         "you must pass a list of names "
+                                         "equal in length to number.")
+                    else:
+                        # The user set a non-3/5/7 number but correctly
+                        # provided a list of names.
+                        pass
+                except TypeError:
+                    # Number was set but names left default (None)
+                    raise ValueError("If number is not 3, 5, or 7, "
+                                     "you must pass a list of names "
+                                     "equal in length to number.")
 
             if variable_type.lower() == 'quality':
                 names = ['dismal',

--- a/skfuzzy/control/fuzzyvariable.py
+++ b/skfuzzy/control/fuzzyvariable.py
@@ -176,24 +176,11 @@ class FuzzyVariable(object):
         if names is not None:
             # set number based on names passed
             number = len(names)
-            if number % 2 != 1:
-                raise ValueError("Must provide an odd number of names")
         else:
             if number not in [3, 5, 7]:
-                try:
-                    if len(names) != number:
-                        raise ValueError("If number is not 3, 5, or 7, "
-                                         "you must pass a list of names "
-                                         "equal in length to number.")
-                    else:
-                        # The user set a non-3/5/7 number but correctly
-                        # provided a list of names.
-                        pass
-                except TypeError:
-                    # Number was set but names left default (None)
-                    raise ValueError("If number is not 3, 5, or 7, "
-                                     "you must pass a list of names "
-                                     "equal in length to number.")
+                raise ValueError("If number is not 3, 5, or 7, "
+                                 "you must pass a list of names "
+                                 "equal in length to number.")
 
             if variable_type.lower() == 'quality':
                 names = ['dismal',

--- a/skfuzzy/control/tests/test_fuzzyvariables.py
+++ b/skfuzzy/control/tests/test_fuzzyvariables.py
@@ -243,10 +243,10 @@ def test_automf_bad():
     global ant
     global con
 
-    tst.assert_raises(ValueError, ant.automf, 4)
-    tst.assert_raises(ValueError, ant.automf, 13)
-    tst.assert_raises(ValueError, con.automf, 4)
-    tst.assert_raises(ValueError, con.automf, 13)
+    tst.assert_raises(ValueError, ant.automf, 4.1)
+    tst.assert_raises(ValueError, ant.automf, np.pi)
+    tst.assert_raises(ValueError, con.automf, 4.1)
+    tst.assert_raises(ValueError, con.automf, np.pi)
 
 
 


### PR DESCRIPTION
Closes #140 with additional logic and checks.  The `number` is now arbitrary (though obviously only integer) and if not 3, 5, or 7 a check is made if the user provided an iterable of `names` with length equal to `number`.