### PR TITLE
To promote compatibility with version 3.7 of python

### DIFF
--- a/skfuzzy/control/controlsystem.py
+++ b/skfuzzy/control/controlsystem.py
@@ -771,7 +771,10 @@ class RuleOrderGenerator(object):
 
         if len(skipped_rules) == 0:
             # All done!
-            return
+            try:
+                skipped_rules
+            except StopIteration:
+                return
         else:
             if len(skipped_rules) == len_rules:
                 # Avoid being caught in an infinite loop

--- a/skfuzzy/control/controlsystem.py
+++ b/skfuzzy/control/controlsystem.py
@@ -772,7 +772,7 @@ class RuleOrderGenerator(object):
         if len(skipped_rules) == 0:
             # All done!
             try:
-                skipped_rules
+                return
             except StopIteration:
                 return
         else:


### PR DESCRIPTION
This happens because PEP 479 made a change to generators: when StopIteration is raised inside a generator, it is replaced with RuntimeError when the exception is about to bubble out of the generator. This behaviour is not backwards compatible and was slowly introduced with this transition plan.