### PR TITLE
fix fuzzy logic range bug: resample should contain the max number

### DIFF
--- a/skfuzzy/fuzzymath/fuzzy_logic.py
+++ b/skfuzzy/fuzzymath/fuzzy_logic.py
@@ -16,7 +16,7 @@ def _resampleuniverse(x, mfx, y, mfy):
     minstep = np.asarray([np.diff(x).min(), np.diff(y).min()]).min()
 
     mi = min(x.min(), y.min())
-    ma = max(x.max(), y.max()) + 0.5 * minstep 
+    ma = max(x.max(), y.max()) + 0.5 * minstep
     z = np.r_[mi:ma:minstep]
 
     xidx = np.argsort(x)

--- a/skfuzzy/fuzzymath/fuzzy_logic.py
+++ b/skfuzzy/fuzzymath/fuzzy_logic.py
@@ -16,7 +16,7 @@ def _resampleuniverse(x, mfx, y, mfy):
     minstep = np.asarray([np.diff(x).min(), np.diff(y).min()]).min()
 
     mi = min(x.min(), y.min())
-    ma = max(x.max(), y.max()) + minstep
+    ma = max(x.max(), y.max()) + 0.5 * minstep 
     z = np.r_[mi:ma:minstep]
 
     xidx = np.argsort(x)

--- a/skfuzzy/fuzzymath/fuzzy_logic.py
+++ b/skfuzzy/fuzzymath/fuzzy_logic.py
@@ -16,7 +16,7 @@ def _resampleuniverse(x, mfx, y, mfy):
     minstep = np.asarray([np.diff(x).min(), np.diff(y).min()]).min()
 
     mi = min(x.min(), y.min())
-    ma = max(x.max(), y.max())
+    ma = max(x.max(), y.max()) + minstep
     z = np.r_[mi:ma:minstep]
 
     xidx = np.argsort(x)


### PR DESCRIPTION
One line test case:
debug = np.r_[0:10:0.5]

For the fuzzy logic AND/OR, It should contain all the source items from my understanding. 

The detail fuzzy logic test case, please see:
https://github.com/caigen/scikit-fuzzy-examples/blob/master/2-fuzzy-logic.py