### PR TITLE
Use spaces, not tabs

### DIFF
--- a/skfuzzy/image/__init__.py
+++ b/skfuzzy/image/__init__.py
@@ -15,6 +15,6 @@ from .metrics import nmse
 import numpy as np
 from distutils.version import LooseVersion
 if LooseVersion(np.__version__) > LooseVersion("1.8"):
-	from numpy import pad
+    from numpy import pad
 else:
-	from .arraypad import pad
+    from .arraypad import pad


### PR DESCRIPTION
Replacing two tabs in skfuzzy.image.__init__.py (only two found, everything else using spaces)