### PR TITLE
Feature: Accept term labels as input values in a control system simulation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 *.md5
 *.old
 *.DS_Store
-docs/source/api
+docs/api
 docs/build
 docs/source/api
 build

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
     - conda config --set always_yes yes;
     - conda update conda;
     - conda info -a;
-    - travis_retry conda create -n test $ENV scipy pip flake8 nose networkx matplotlib;
+    - travis_retry conda create -n test $ENV scipy pip pytest flake8 nose networkx matplotlib;
     - source activate test;
     - travis_retry conda install pillow;
     - travis_retry pip install coveralls

--- a/skfuzzy/control/controlsystem.py
+++ b/skfuzzy/control/controlsystem.py
@@ -141,6 +141,10 @@ class _InputAcceptor(object):
     Inputs can be singletons or arrays, but all Antecedent inputs must match.
     If they are arrays, all must have the exact same shape.  If they are
     arrays, the output(s) will carry the same shape as the inputs.
+
+    An input value can be a "crisp" numerical value, which is fuzzified, or it
+    can be a (valid) term label, in which case the membership value for that
+    term will be set to 1 (and 0 for the others).
     """
 
     def __init__(self, simulation):

--- a/skfuzzy/control/controlsystem.py
+++ b/skfuzzy/control/controlsystem.py
@@ -151,47 +151,53 @@ class _InputAcceptor(object):
         # Find the antecedent we should set the input for
         matches = [n for n in self.sim.ctrl.graph.nodes()
                    if isinstance(n, Antecedent) and n.label == key]
-
         if len(matches) == 0:
             raise ValueError("Unexpected input: " + key)
         assert len(matches) == 1
         var = matches[0]
 
-        # Inform the simulation there is an array input
-        if isinstance(value, np.ndarray):
-            self.sim._array_inputs = True
-            # Check if this is the correct array input
-            if self.sim._array_shape is not None:
-                if self.sim._array_shape != value.shape:
-                    warn("Input array is shape {0}, which is different from "
-                         "previous array(s) which were {1}.  This may cause "
-                         "problems, unless you are replacing all "
-                         "inputs.".format(value.shape, self.sim._array_shape))
-            self.sim._array_shape = value.shape
-            maxval = value.max(initial=0)
-            minval = value.min(initial=0)
+        if isinstance(value, Term):
+            value = value.label
+        elif isinstance(value, str):
+            pass
         else:
-            # Input isn't an array, but we saw arrays before... reset!
-            if self.sim._array_inputs is not False:
-                warn("This system previously accepted array inputs.  It will "
-                     "be reset to operate on the singleton input just passed.")
-                self.sim.reset()
-                self.sim._array_shape = False
-            maxval = value
-            minval = value
+            if isinstance(value, np.ndarray):
+                # Inform the simulation there is an array input
+                self.sim._array_inputs = True
+                # Check if this is the correct array input
+                if self.sim._array_shape is not None:
+                    if self.sim._array_shape != value.shape:
+                        warn("Input array is shape {0}, which is different "
+                             "from previous array(s) which were {1}.  This "
+                             "may cause problems, unless you are replacing "
+                             "all inputs."
+                             .format(value.shape, self.sim._array_shape))
+                self.sim._array_shape = value.shape
+                maxval = value.max(initial=0)
+                minval = value.min(initial=0)
+            else:
+                # Input isn't an array, but we saw arrays before... reset!
+                if self.sim._array_inputs is not False:
+                    warn("This system previously accepted array inputs.  It "
+                         "will be reset to operate on the singleton input "
+                         "just passed.")
+                    self.sim.reset()
+                    self.sim._array_shape = False
+                maxval = value
+                minval = value
 
-        if maxval > var.universe.max():
-            if self.sim.clip_to_bounds:
-                value = np.fmin(value, var.universe.max())
-            else:
-                raise IndexError("Input value out of bounds. Max is {}."
-                                 .format(max(var.universe)))
-        if minval < var.universe.min():
-            if self.sim.clip_to_bounds:
-                value = np.fmax(value, var.universe.min())
-            else:
-                raise IndexError("Input value is out of bounds. Min is {}."
-                                 .format(min(var.universe)))
+            if maxval > var.universe.max():
+                if self.sim.clip_to_bounds:
+                    value = np.fmin(value, var.universe.max())
+                else:
+                    raise IndexError("Input value out of bounds. Max is {}."
+                                     .format(max(var.universe)))
+            if minval < var.universe.min():
+                if self.sim.clip_to_bounds:
+                    value = np.fmax(value, var.universe.min())
+                else:
+                    raise IndexError("Input value is out of bounds. Min is {}."
+                                     .format(min(var.universe)))
 
         var.input['current'] = value
         self.sim._update_unique_id()
@@ -597,13 +603,22 @@ class CrispValueCalculator(object):
     def fuzz(self, value):
         """
         Propagate crisp value down to adjectives by calculating membership.
+
+        This function accepts either a crisp value or a term label.
         """
         if len(self.var.terms) == 0:
-            raise ValueError("Set Term membership function(s) first")
+            raise ValueError("No terms and membership functions were yet "
+                             "specified for the fuzzy variable '{}'."
+                             .format(self.var.label))
 
-        for label, term in self.var.terms.items():
-            term.membership_value[self.sim] = \
-                interp_membership(self.var.universe, term.mf, value)
+        if isinstance(value, str):
+            for label, term in self.var.terms.items():
+                term.membership_value[self.sim] = \
+                    1 if term.label == value else 0
+        else:
+            for label, term in self.var.terms.items():
+                term.membership_value[self.sim] = \
+                    interp_membership(self.var.universe, term.mf, value)
 
     def find_memberships(self):
         """

--- a/skfuzzy/control/tests/test_controlsystem.py
+++ b/skfuzzy/control/tests/test_controlsystem.py
@@ -4,6 +4,7 @@ import numpy as np
 import numpy.testing as tst
 import skfuzzy as fuzz
 import skfuzzy.control as ctrl
+from pytest import approx
 
 try:
     from numpy.testing.decorators import skipif
@@ -477,6 +478,41 @@ def test_complex_system():
 
     # Ensure results are within expected limits
     np.testing.assert_allclose(z1, expected)
+
+
+def test_simulation_with_standard_values_1():
+    x1 = ctrl.Antecedent(np.linspace(0, 10, 11), "x1")
+    x1.automf(3)  # term labels: poor, average, good
+    x2 = ctrl.Antecedent(np.linspace(0, 10, 11), "x2")
+    x2.automf(3)
+
+    y1 = ctrl.Consequent(np.linspace(0, 10, 11), "y1")
+    y1.automf(3)
+
+    r1 = ctrl.Rule(x1["poor"], y1["good"])
+    r2 = ctrl.Rule(x1["average"], y1["average"])
+    r3 = ctrl.Rule(x1["good"], y1["poor"])
+    sys = ctrl.ControlSystem([r1, r2, r3])
+
+    sim = ctrl.ControlSystemSimulation(sys)
+
+    sim.input["x1"] = "poor"
+    sim.compute()
+    assert set(sim.output.keys()) == {"y1"}
+    # print("- sim.output['y1']:", sim.output["y1"])
+    assert sim.output["y1"] == approx(8.333333)
+
+    sim.input["x1"] = "average"
+    sim.compute()
+    assert set(sim.output.keys()) == {"y1"}
+    # print("- sim.output['y1']:", sim.output["y1"])
+    assert sim.output["y1"] == approx(5)
+
+    sim.input["x1"] = "good"
+    sim.compute()
+    assert set(sim.output.keys()) == {"y1"}
+    # print("- sim.output['y1']:", sim.output["y1"])
+    assert sim.output["y1"] == approx(1.666667)
 
 
 if __name__ == '__main__':

--- a/skfuzzy/control/tests/test_crisp_value_calculator.py
+++ b/skfuzzy/control/tests/test_crisp_value_calculator.py
@@ -1,0 +1,52 @@
+import numpy as np
+
+from skfuzzy.control.controlsystem import (
+    Antecedent, Consequent, ControlSystem, ControlSystemSimulation,
+    CrispValueCalculator, Rule,
+)
+
+
+def test_crisp_value_calculator_1():
+    x1 = Antecedent(np.linspace(0, 10, 11), "x1")
+    x1.automf(3)  # term labels: poor, average, good
+    x2 = Antecedent(np.linspace(0, 10, 11), "x2")
+    x2.automf(3)
+
+    y1 = Consequent(np.linspace(0, 10, 11), "y1")
+    y1.automf(3)
+    y2 = Consequent(np.linspace(0, 10, 11), "y2")
+    y2.automf(3)
+
+    r1 = Rule(x1["poor"], y1["good"])
+    r2 = Rule(x2["poor"], y2["good"])
+    sys = ControlSystem([r1, r2])
+
+    sim = ControlSystemSimulation(sys)
+    cvc = CrispValueCalculator(x1, sim)
+
+    cvc.fuzz(0)
+    values = {label: term.membership_value[sim]
+              for label, term in x1.terms.items()}
+    assert values == {
+        "poor": 1,
+        "average": 0,
+        "good": 0,
+    }
+
+    cvc.fuzz(2.5)
+    values = {label: term.membership_value[sim]
+              for label, term in x1.terms.items()}
+    assert values == {
+        "poor": .5,
+        "average": .5,
+        "good": 0,
+    }
+
+    cvc.fuzz("average")
+    values = {label: term.membership_value[sim]
+              for label, term in x1.terms.items()}
+    assert values == {
+        "poor": 0,
+        "average": 1,
+        "good": 0,
+    }

--- a/skfuzzy/control/tests/test_terms.py
+++ b/skfuzzy/control/tests/test_terms.py
@@ -1,0 +1,29 @@
+# test_terms
+
+from inspect import isfunction, ismethod
+import numpy as np
+
+
+from skfuzzy.control import (
+    ControlSystem, ControlSystemSimulation, Antecedent, Consequent, Rule,
+)
+# from skfuzzy.control.controlsystem import CrispValueCalculator
+from skfuzzy.control.term import TermAggregate, FuzzyAggregationMethods
+
+
+def test_term_aggregate_1():
+    x1 = Antecedent(np.linspace(0, 10, 11), "x1")
+    x1.automf(3)  # term labels: poor, average, good
+    x2 = Antecedent(np.linspace(0, 10, 11), "x2")
+    x2.automf(3)
+    ta = (x1["poor"] & x2["good"])
+    # print("- ta:", ta)
+    assert isinstance(ta, TermAggregate)
+    assert str(ta) == "x1[poor] AND x2[good]"
+
+
+def test_fuzzy_aggregation_methods():
+    fam = FuzzyAggregationMethods()
+    # print("- type(fam.and_func):", type(fam.and_func))
+    assert isinstance(fam.and_func, np.ufunc)
+    assert isinstance(fam.or_func, np.ufunc)

--- a/tox.ini
+++ b/tox.ini
@@ -14,15 +14,12 @@ deps =
     numpy>=1.6.0
     scikit-image>=0.10
     scipy>=0.9.0
-    .
+    -e .
 
-    test: flake8>=3.8.3
-    test: nose>=1.3.7
-    test: pytest>=5.4.3
+    {test,watch}: flake8>=3.8.3
+    {test,watch}: nose>=1.3.7
+    {test,watch}: pytest>=5.4.3
 
-    watch: flake8>=3.8.3
-    watch: nose>=1.3.7
-    watch: pytest>=5.4.3
     watch: pytest-watch>=4.2.0
 commands =
     pytest -x -ra skfuzzy docs/examples
@@ -32,7 +29,7 @@ usedevelop =
 
 [testenv:py38-watch]
 commands =
-    pytest-watch -- skfuzzy docs/examples
+    pytest-watch -- -s skfuzzy docs/examples
 
 [pytest]
 junit_family = xunit1


### PR DESCRIPTION
An input value for a fuzzy control system simulation can now be a (valid) term label, in which case the membership value for that term will be set to 1 (and 0 for the others). This can be useful when, for example, the input is obtained by means of a user interface in which the user can make a convenient/meaningful choice by picking one of the terms instead of having to provide a concrete value from some arbitrary universe.