### PR TITLE
Fix docs auto-deployment and limit it only to one travis env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,16 +50,17 @@ script:
 
 after_success:
     - coveralls
-    - cd docs && make
-
+    
 before_deploy:
-    - touch docs/build/html/.nojekyll
+    - cd docs && make
+    - touch build/html/.nojekyll
 
 deploy:
   provider: pages
-  cleanup: false
+  skip_cleanup: true
   token: $TRAVIS_DEPLOY
   keep_history: true
   local_dir: docs/build/html
   on:
     branch: master
+    condition: $ENV = "python=3.8 numpy"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ https://github.com/scikit-fuzzy/scikit-fuzzy
 Documentation
 -------------
 
-The documentation of the library can be found here : http://pythonhosted.org/scikit-fuzzy
+The documentation of the library can be found here: https://scikit-fuzzy.github.io/scikit-fuzzy
 
 Online Discussion & Mailing List
 --------------------------------


### PR DESCRIPTION
Hi!
The change brings **fix for auto-deployment** - the previous version was cleaning up _docs/build_ dir before deployment :facepalm:. Also I've made an **update to README**, so now it will point to the latest docs on gh-pages.

@JDWarner for this to work, we need to have $TRAVIS_DEPLOY environmental variable set up in Travis with scikit-fuzzy's personal access token. I don't have any way to check if we have it already done or not, so I want to make sure :)

I will start working on our CI/CD migration to GitHub Actions sometime soon, but for now we also need our Travis to work properly :wink: