### PR TITLE
MAINT: Scipy removed `pinv2`, in favor of `pinv`

### DIFF
--- a/skfuzzy/fuzzymath/_continuous_to_discrete.py
+++ b/skfuzzy/fuzzymath/_continuous_to_discrete.py
@@ -30,7 +30,7 @@ def continuous_to_discrete(a, b, sampling_rate):
 
     phi = scipy.linalg.expm(a * sampling_rate)
 
-    a_pinv = scipy.linalg.pinv2(a)
+    a_pinv = scipy.linalg.pinv(a)
 
     gamma = np.dot(np.dot(a_pinv, phi - np.eye(a.shape[0])), b)
 


### PR DESCRIPTION
Minor fix due to recent Scipy removal of the deprecated `scipy.linalg.pinv2` in favor of `pinv`.

This should also be backwards compatible.