### PR TITLE
Gitwash test

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -109,6 +109,7 @@ gitwash:
 	$(PYTHON) tools/gitwash/gitwash_dumper.py source scikit-fuzzy \
 	--project-url=https://scikit-fuzzy.github.io/scikit-fuzzy/ \
 	--project-ml-url=http://groups.google.com/group/scikit-fuzzy \
+	--gitwash-url=https://github.com/matthew-brett/gitwash.git \
 	--repo-name=scikit-fuzzy \
 	--github-user=scikit-fuzzy \
 	--source-suffix=.txt

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -107,7 +107,7 @@ doctest:
 gitwash:
 	git submodule update --init --recursive
 	$(PYTHON) tools/gitwash/gitwash_dumper.py source scikit-fuzzy \
-	--project-url=http://scikit-fuzzy.org \
+	--project-url=https://scikit-fuzzy.github.io/scikit-fuzzy/ \
 	--project-ml-url=http://groups.google.com/group/scikit-fuzzy \
 	--repo-name=scikit-fuzzy \
 	--github-user=scikit-fuzzy \


### PR DESCRIPTION
Gitwash had a bug where the default URL still used `git://` to access its repo.  This was the cause of our GH Actions failures, which *should* now be resolved.  I've submitted a PR over there to fix it for anyone else, but directly specifying the `--gitwash-url` should fix it here immediately and durably.

Supersedes #288.  Cleanup after #280.  

Pinging @balins - thanks again for your help migrating to GH Actions and fingers crossed the suite should (finally) be green!