### PR TITLE
Adapt tests to numpy 1.25

### DIFF
--- a/skfuzzy/control/tests/_skipclass.py
+++ b/skfuzzy/control/tests/_skipclass.py
@@ -1,3 +1,4 @@
+import collections.abc
 import functools
 import types
 try:
@@ -41,3 +42,81 @@ def skipclassif(condition, reason):
     if condition:
         return skip(reason)
     return _id
+
+
+def skipif(skip_condition, msg=None):
+    """
+    Copied from numpy < 1.25
+
+    Make function raise SkipTest exception if a given condition is true.
+
+    If the condition is a callable, it is used at runtime to dynamically
+    make the decision. This is useful for tests that may require costly
+    imports, to delay the cost until the test suite is actually executed.
+
+    Parameters
+    ----------
+    skip_condition : bool or callable
+        Flag to determine whether to skip the decorated test.
+    msg : str, optional
+        Message to give on raising a SkipTest exception. Default is None.
+
+    Returns
+    -------
+    decorator : function
+        Decorator which, when applied to a function, causes SkipTest
+        to be raised when `skip_condition` is True, and the function
+        to be called normally otherwise.
+
+    Notes
+    -----
+    The decorator itself is decorated with the ``nose.tools.make_decorator``
+    function in order to transmit function name, and various other metadata.
+
+    """
+
+    def skip_decorator(f):
+        # Local import to avoid a hard nose dependency and only incur the
+        # import time overhead at actual test-time.
+        import nose
+
+        # Allow for both boolean or callable skip conditions.
+        if isinstance(skip_condition, collections.abc.Callable):
+            skip_val = lambda: skip_condition()
+        else:
+            skip_val = lambda: skip_condition
+
+        def get_msg(func, msg=None):
+            """Skip message with information about function being skipped."""
+            if msg is None:
+                out = 'Test skipped due to test condition'
+            else:
+                out = msg
+
+            return f'Skipping test: {func.__name__}: {out}'
+
+        # We need to define *two* skippers because Python doesn't allow both
+        # return with value and yield inside the same function.
+        def skipper_func(*args, **kwargs):
+            """Skipper for normal test functions."""
+            if skip_val():
+                raise SkipTest(get_msg(f, msg))
+            else:
+                return f(*args, **kwargs)
+
+        def skipper_gen(*args, **kwargs):
+            """Skipper for test generators."""
+            if skip_val():
+                raise SkipTest(get_msg(f, msg))
+            else:
+                yield from f(*args, **kwargs)
+
+        # Choose the right skipper to use when building the actual decorator.
+        if nose.util.isgenerator(f):
+            skipper = skipper_gen
+        else:
+            skipper = skipper_func
+
+        return nose.tools.make_decorator(f)(skipper)
+
+    return skip_decorator

--- a/skfuzzy/control/tests/test_controlsystem.py
+++ b/skfuzzy/control/tests/test_controlsystem.py
@@ -7,13 +7,7 @@ import skfuzzy.control as ctrl
 from pytest import approx, raises
 from distutils.version import StrictVersion
 
-try:
-    from numpy.testing.decorators import skipif
-except AttributeError:
-    from numpy.testing.dec import skipif
-except ModuleNotFoundError:
-    from numpy.testing import dec
-    skipif = dec.skipif
+from _skipclass import skipif
 
 from skfuzzy.control import EmptyMembershipError
 

--- a/skfuzzy/fuzzymath/fuzzy_ops.py
+++ b/skfuzzy/fuzzymath/fuzzy_ops.py
@@ -272,7 +272,7 @@ def fuzzy_compare(q):
         Comparison matrix.
 
     """
-    return q.T / np.fmax(q, q.T).astype(np.float)
+    return q.T / np.fmax(q, q.T).astype(float)
 
 
 def fuzzy_div(x, a, y, b):

--- a/skfuzzy/image/tests/test_imops.py
+++ b/skfuzzy/image/tests/test_imops.py
@@ -5,7 +5,7 @@ import os
 
 import numpy as np
 import skfuzzy.image
-from numpy.testing import (assert_allclose, TestCase, run_module_suite)
+from numpy.testing import (assert_allclose, TestCase)
 from skfuzzy.image import defocus_local_means, view_as_windows, pad
 
 
@@ -35,7 +35,3 @@ class TestDefocusLocalMeans(TestCase):
             (3, 3))[:, :, [1, 1, 0, 2], [0, 2, 1, 1]].mean(axis=2)
 
         assert_allclose(result, expected)
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/skfuzzy/image/tests/test_pad.py
+++ b/skfuzzy/image/tests/test_pad.py
@@ -7,13 +7,6 @@ import numpy as np
 from numpy.testing import (assert_array_equal, assert_raises, assert_allclose,
                            TestCase)
 
-try:
-    from numpy.testing.decorators import skipif
-except AttributeError:
-    from numpy.testing.dec import skipif
-except ModuleNotFoundError:
-    from numpy.testing import dec
-    skipif = dec.skipif
 from _skipclass import skipclassif
 
 from skfuzzy.image import pad


### PR DESCRIPTION
numpy 1.25 removed a lot of their nose helpers. This PR copies over one of the ones we were using and stops calling another method that was removed.

I think that long term, `nose` should be phased out. I could also work on that approach to, though this is the simplest fix that I could think of that I'm going to for now apply in [nixpkgs](https://github.com/NixOS/nixpkgs) to fix this package there.