### PR TITLE
TSTFIX: Drop Python 3.6 to fix test suite, add 3.10-11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python: [3.7, 3.8, 3.9, 3.10, 3.11]
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
       - uses: actions/checkout@v2
@@ -52,7 +52,7 @@ jobs:
           github.repository == 'scikit-fuzzy/scikit-fuzzy' &&
           github.ref == 'ref/head/master' &&
           matrix.os == 'ubuntu-latest' &&
-          matrix.python == 3.11
+          matrix.python == '3.11'
         with:
           personal_token: ${{ secrets.API_TOKEN_GITHUB }}
           external_repository: 'scikit-fuzzy/scikit-fuzzy.github.io'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python: [3.6, 3.7, 3.8, 3.9]
+        python: [3.7, 3.8, 3.9, 3.10, 3.11]
 
     steps:
       - uses: actions/checkout@v2
@@ -52,7 +52,7 @@ jobs:
           github.repository == 'scikit-fuzzy/scikit-fuzzy' &&
           github.ref == 'ref/head/master' &&
           matrix.os == 'ubuntu-latest' &&
-          matrix.python == 3.9
+          matrix.python == 3.11
         with:
           personal_token: ${{ secrets.API_TOKEN_GITHUB }}
           external_repository: 'scikit-fuzzy/scikit-fuzzy.github.io'


### PR DESCRIPTION
Drop Python 3.6 from the test suite as this Python is no longer supported in our GH-Actions test suite architecture.

Add Python 3.10 and 3.11.  Build and deploy docs from the 3.11 branch.