### PR TITLE
TSTFIX: Temporarily limit test matrix to 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python: [3.8, 3.9, "3.10", 3.11]  # , 3.12]  # Matplotlib is not yet Py3.12 compatible
+        python: [3.8, 3.9] # Nose limited to 3.9, Matplotlib is not yet Py3.12 compatible
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ jobs:
   main:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
         python: [3.8, 3.9] # Nose limited to 3.9, Matplotlib is not yet Py3.12 compatible

--- a/skfuzzy/control/rule.py
+++ b/skfuzzy/control/rule.py
@@ -249,7 +249,7 @@ class Rule(object):
                            dir(self.antecedent) if
                            not attr.startswith("__")]
         for method in antecedent_attr:
-            if type(method) == Term:
+            if isinstance(method, Term):
                 active_label = method.label
                 nodes.append(method.parent.label)
                 colors.append([method.parent.label, 'green'])

--- a/skfuzzy/control/tests/_skipclass.py
+++ b/skfuzzy/control/tests/_skipclass.py
@@ -82,9 +82,9 @@ def skipif(skip_condition, msg=None):
 
         # Allow for both boolean or callable skip conditions.
         if isinstance(skip_condition, collections.abc.Callable):
-            skip_val = lambda: skip_condition()
+            skip_val = lambda: skip_condition()  # noqa: E731
         else:
-            skip_val = lambda: skip_condition
+            skip_val = lambda: skip_condition    # noqa: E731
 
         def get_msg(func, msg=None):
             """Skip message with information about function being skipped."""


### PR DESCRIPTION
Nose is unsupported and broken starting in 3.10.  

This is a temporary stopgap measure until the test suite is converted to `pytest`; see #302.