### PR TITLE
Lint Python code with ruff instead of flake8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           pytest
           # pytest --doctest-modules  # TODO: Fix four failing doctests
-          flake8 --exclude=test_* skfuzzy docs/examples
+          ruff --format=github .
       - name: Build docs
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/CONTRIBUTING.txt
+++ b/CONTRIBUTING.txt
@@ -136,7 +136,7 @@ Stylistic Guidelines
 --------------------
 
 * Set up your editor to remove trailing whitespace.  Follow `PEP08
-  <www.python.org/dev/peps/pep-0008/>`__.  Check code with pyflakes / flake8.
+  <www.python.org/dev/peps/pep-0008/>`__.  Check code with ruff.
 
 * Use numpy data types instead of strings, e.g., ``np.uint8`` instead of
   ``"uint8"``.

--- a/DEPENDS-tests.txt
+++ b/DEPENDS-tests.txt
@@ -3,6 +3,6 @@
 ####################################################################
 -r DEPENDS.txt
 coveralls
-flake8
 packaging
 pytest
+ruff

--- a/docs/ext/docscrape.py
+++ b/docs/ext/docscrape.py
@@ -6,7 +6,6 @@ import inspect
 import textwrap
 import re
 import pydoc
-from io import BytesIO
 from warnings import warn
 
 
@@ -427,7 +426,7 @@ class FunctionDoc(NumpyDocString):
                 argspec = inspect.formatargspec(*argspec)
                 argspec = argspec.replace('*','\*')
                 signature = '%s%s' % (func_name, argspec)
-            except TypeError as e:
+            except TypeError:
                 signature = '%s()' % func_name
             self['Signature'] = signature
 
@@ -443,7 +442,7 @@ class FunctionDoc(NumpyDocString):
         out = ''
 
         func, func_name = self.get_func()
-        signature = self['Signature'].replace('*', '\*')
+        self['Signature'].replace('*', '\*')
 
         roles = {'func': 'function',
                  'meth': 'method'}

--- a/docs/ext/notebook_doc.py
+++ b/docs/ext/notebook_doc.py
@@ -1,4 +1,4 @@
-__all__ = ['python_to_notebook', 'Notebook']
+__all__ = ['Notebook']
 
 import json
 import copy

--- a/docs/ext/numpydoc.py
+++ b/docs/ext/numpydoc.py
@@ -16,7 +16,7 @@ It will:
 
 """
 
-import os, re, pydoc
+import re, pydoc
 from docscrape_sphinx import get_doc_object, SphinxDocString
 import inspect
 

--- a/docs/ext/plot2rst.py
+++ b/docs/ext/plot2rst.py
@@ -71,7 +71,6 @@ import shutil
 import token
 import tokenize
 import traceback
-import itertools
 
 import numpy as np
 import matplotlib

--- a/docs/ext/plot_directive.py
+++ b/docs/ext/plot_directive.py
@@ -515,7 +515,7 @@ def run_code(code, code_path, ns=None, function_name=None):
                 if function_name is not None:
                     exec(function_name + "()", ns)
 
-        except (Exception, SystemExit) as err:
+        except (Exception, SystemExit):
             raise PlotError(traceback.format_exc())
         finally:
             os.chdir(pwd)
@@ -641,7 +641,7 @@ def render_figures(code, code_path, output_dir, output_base, context,
             for format, dpi in formats:
                 try:
                     figman.canvas.figure.savefig(img.filename(format), dpi=dpi)
-                except Exception as err:
+                except Exception:
                     raise PlotError(traceback.format_exc())
                 img.formats.append(format)
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,10 @@
+line-length=126
+
+[per-file-ignores]
+"docs/ext/docscrape_sphinx.py" = ["E401"]
+"docs/ext/docscrape.py" = ["E701", "E741"]
+"docs/ext/numpydoc.py" = ["E401", "E402", "E701"]
+"docs/ext/plot2rst.py" = ["E402"]
+"docs/source/conf.py" = ["E402"]
+"docs/tools/plot_pr.py" = ["E741"]
+"setup.py" = ["E402"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[flake8]
-exclude = .cache,.git,.tox,build,dist,docs,./*/_/frameworks/,__pycache__
-
 [metadata]
 description-file = README.md
 

--- a/skfuzzy/__init__.py
+++ b/skfuzzy/__init__.py
@@ -85,7 +85,7 @@ Try re-installing the package."""
 
 def _raise_build_error(e):
     # Raise a comprehensible error
-    local_dir = osp.split(__file__)[0]  # noqa: F405
+    local_dir = osp.split(__file__)[0]  # noqa: F405,F821
     msg = _STANDARD_MSG
     if local_dir == "skfuzzy":
         # Picking up the local install: this will work only if the

--- a/skfuzzy/control/tests/test_terms.py
+++ b/skfuzzy/control/tests/test_terms.py
@@ -1,11 +1,10 @@
 # test_terms
 
-from inspect import isfunction, ismethod
 import numpy as np
 
 
 from skfuzzy.control import (
-    ControlSystem, ControlSystemSimulation, Antecedent, Consequent, Rule,
+    Antecedent,
 )
 # from skfuzzy.control.controlsystem import CrispValueCalculator
 from skfuzzy.control.term import TermAggregate, FuzzyAggregationMethods

--- a/tools/build_versions.py
+++ b/tools/build_versions.py
@@ -6,7 +6,7 @@ import scipy as sp
 from PIL import Image
 
 for m in (np, sp, Image, networkx):
-    if not m is None:
+    if m is not None:
         if m is Image:
             # Pillow 6.0.0 and above have removed the 'VERSION' attribute
             # https://bitbucket.org/rptlab/reportlab/issues/176/incompatibility-with-pillow-600

--- a/tox.ini
+++ b/tox.ini
@@ -16,13 +16,13 @@ deps =
     scipy>=0.9.0
     -e .
 
-    {test,watch}: flake8>=3.8.3
+    {test,watch}: ruff>=0.0.287
     {test,watch}: pytest>=7.4.2
 
     watch: pytest-watch>=4.2.0
 commands =
     pytest -x -ra skfuzzy docs/examples
-    flake8 --exclude=test_* skfuzzy docs/examples
+    ruff .
 usedevelop =
     local: true
 


### PR DESCRIPTION
[Ruff](https://beta.ruff.rs/) supports [over 600 lint rules](https://beta.ruff.rs/docs/rules) and can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [yesqa](https://github.com/asottile/yesqa), [eradicate](https://pypi.org/project/eradicate/), [pyupgrade](https://pypi.org/project/pyupgrade/), and [autoflake](https://pypi.org/project/autoflake/), all while executing (in Rust) tens or hundreds of times faster than any individual tool.

`ruff --format=github` rapidly provides intuitive GitHub Annotations to contributors.

![image](https://user-images.githubusercontent.com/3709715/223758136-afc386d2-70aa-4eff-953a-2c2d82ceea23.png)
