### PR TITLE
ruff rule W605: Fix invalid escape sequences

### DIFF
--- a/docs/ext/docscrape.py
+++ b/docs/ext/docscrape.py
@@ -266,7 +266,7 @@ class NumpyDocString(object):
 
         summary = self._doc.read_to_next_empty_line()
         summary_str = " ".join([s.strip() for s in summary]).strip()
-        if re.compile('^([\w., ]+=)?\s*[\w\.]+\(.*\)$').match(summary_str):
+        if re.compile(r'^([\w., ]+=)?\s*[\w\.]+\(.*\)$').match(summary_str):
             self['Signature'] = summary_str
             if not self._is_at_section():
                 self['Summary'] = self._doc.read_to_next_empty_line()
@@ -306,7 +306,7 @@ class NumpyDocString(object):
 
     def _str_signature(self):
         if self['Signature']:
-            return [self['Signature'].replace('*','\*')] + ['']
+            return [self['Signature'].replace('*',r'\*')] + ['']
         else:
             return ['']
 
@@ -424,7 +424,7 @@ class FunctionDoc(NumpyDocString):
                 # try to read signature
                 argspec = inspect.getargspec(func)
                 argspec = inspect.formatargspec(*argspec)
-                argspec = argspec.replace('*','\*')
+                argspec = argspec.replace('*',r'\*')
                 signature = '%s%s' % (func_name, argspec)
             except TypeError:
                 signature = '%s()' % func_name
@@ -442,7 +442,7 @@ class FunctionDoc(NumpyDocString):
         out = ''
 
         func, func_name = self.get_func()
-        self['Signature'].replace('*', '\*')
+        self['Signature'].replace('*', r'\*')
 
         roles = {'func': 'function',
                  'meth': 'method'}

--- a/docs/ext/plot2rst.py
+++ b/docs/ext/plot2rst.py
@@ -406,7 +406,7 @@ def write_example(src_name, src_dir, rst_dir, cfg):
                          for role in sphinx_roles)
 
     # Grab all references to inject them in cells where needed
-    ref_regexp = re.compile('\n(\.\. \[(\d+)\].*(?:\n[ ]{7,8}.*)+)')
+    ref_regexp = re.compile('\n(\\.\\. \\[(\\d+)\\].*(?:\n[ ]{7,8}.*)+)')
     math_role_regexp = re.compile(':math:`(.*?)`')
 
     text = '\n'.join((content for (cell_type, _, content) in blocks

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,5 @@
-line-length=126
+line-length = 126
+select = ["E", "F", "W"]
 
 [per-file-ignores]
 "docs/ext/docscrape_sphinx.py" = ["E401"]


### PR DESCRIPTION
% `ruff --select=W605 --fix . ` # https://beta.ruff.rs/docs/rules/invalid-escape-sequence
```
Found 14 errors (14 fixed, 0 remaining).
```
% `ruff rule W605`
# invalid-escape-sequence (W605)

Derived from the **pycodestyle** linter.

Autofix is always available.

## What it does
Checks for invalid escape sequences.

## Why is this bad?
Invalid escape sequences are deprecated in Python 3.6.

## Example
```python
regex = "\.png$"
```

Use instead:
```python
regex = r"\.png$"
```

## References
- [Python documentation: String and Bytes literals](https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals)