### PR TITLE
Remove spurious ToC link in doc build to nonexistant page.

### DIFF
--- a/docs/source/index.txt
+++ b/docs/source/index.txt
@@ -60,9 +60,6 @@ Sections
 Indices and tables
 ==================
 
-`Table of Contents <contents.html>`_
-   Lists all sections and subsections.
-
 :ref:`search`
    Search this documentation.
 


### PR DESCRIPTION
Removes the link to a missing page in table of contents.

Closes #321