### PR TITLE
Fix longstanding error which occasionally eroded universes in classic API

### DIFF
--- a/skfuzzy/fuzzymath/fuzzy_logic.py
+++ b/skfuzzy/fuzzymath/fuzzy_logic.py
@@ -16,7 +16,12 @@ def _resampleuniverse(x, mfx, y, mfy):
 
     mi = min(x.min(), y.min())
     ma = max(x.max(), y.max())
-    z = np.r_[mi:ma:minstep]
+    z = np.r_[mi:ma+minstep:minstep]
+
+    # Occasionally this oversteps depending on precision and ends up with too
+    # large of a universe. This checks and eliminates the last point if so.
+    if z.max() > (ma + minstep/2):
+        z = z[:-1]
 
     xidx = np.argsort(x)
     mfx = mfx[xidx]


### PR DESCRIPTION
This occurred due to floating point error in specific edge cases. The result would have been missing the far expected max value, after operations which used `_resampleuniverse`. The bug has existed since the package was introduced. This will break some behavior but is absolutely a bugfix.

HOWEVER!  `skfuzzy.control` uses a different approach to this operation which is more efficient and importantly is correct. This will not change the behavior of systems in production using systems defined through the `skfuzzy.control` API.

Bug report and code to reproduce in #320. Credit to @fabrizioruffini for finding this.

Closes #320.