### PR TITLE
FIX: Correct limit on `maxiter`

### DIFF
--- a/skfuzzy/cluster/_cmeans.py
+++ b/skfuzzy/cluster/_cmeans.py
@@ -168,7 +168,7 @@ def cmeans(data, c, m, error, maxiter,
     p = 0
 
     # Main cmeans loop
-    while p < maxiter - 1:
+    while p < maxiter:
         u2 = u.copy()
         [cntr, u, Jjm, d] = _cmeans0(data, u2, c, m, metric)
         jm = np.hstack((jm, Jjm))
@@ -263,7 +263,7 @@ def cmeans_predict(test_data, cntr_trained, m, error, maxiter,
     p = 0
 
     # Main cmeans loop
-    while p < maxiter - 1:
+    while p < maxiter:
         u2 = u.copy()
         [u, Jjm, d] = _cmeans_predict0(test_data, cntr_trained, u2, c, m,
                                        metric)


### PR DESCRIPTION
Previously the maximum iteration argument `maxiter` actually terminated iteration one loop too early.

Closes #289 