### PR TITLE
FIX: ControlSystemVisualizer initialization now works correctly.

### DIFF
--- a/skfuzzy/control/visualization.py
+++ b/skfuzzy/control/visualization.py
@@ -179,7 +179,7 @@ class ControlSystemVisualizer(object):
             raise ImportError("`ControlSystemVisualizer` can only be used "
                               "with `matplotlib` present in the system.")
 
-            self.ctrl = control_system
+        self.ctrl = control_system
 
         self.fig, self.ax = plt.subplots()
 


### PR DESCRIPTION
Bug reported by @yportier where the essential initialization of the control system in this class was not occurring.

This implements the suggested fix which decreases indentation one level.

Closes #330 and thanks @yportier!